### PR TITLE
Fix missing import and circular resource imports

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,7 +4,6 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_cors import CORS
 from flask_limiter import Limiter
-from resources import Register, Login, Messages
 from flask_jwt_extended import JWTManager
 
 # Initialize Flask app
@@ -28,6 +27,9 @@ api = Api(app)
 
 # Initialize JWTManager for handling JWT authentication
 jwt = JWTManager(app)
+
+# Import resources after initializing app components to avoid circular imports
+from resources import Register, Login, Messages
 
 # Apply rate limiting on the messages resource
 limiter.limit("50/minute")(Messages)

--- a/backend/models.py
+++ b/backend/models.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption, PublicFormat
+from cryptography.hazmat.backends import default_backend
 
 """
 When a new user is registered, a public-private key pair is generated.

--- a/backend/resources.py
+++ b/backend/resources.py
@@ -159,5 +159,3 @@ class Messages(Resource):
         db.session.commit()
 
         return {"message": "Message sent successfully."}, 201
-
-api.add_resource(Login, '/login')


### PR DESCRIPTION
## Summary
- import `default_backend` for cryptography
- load backend resources after initializing the Flask app to avoid circular imports
- remove stray API registration from `resources.py`

## Testing
- `pytest -q`