### PR TITLE
Add tests and expand backend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ To run the application, follow these steps:
 4. (Optional) install frontend dependencies in `frontend` if using Node.
 5. Start the backend with `python backend/app.py` and the frontend with your preferred React tooling.
 6. Open a browser and navigate to the frontend's URL to use the application.
+
+## Running Tests
+Backend unit tests use **pytest**. Once the dependencies are installed you can
+run all tests from the repository root:
+
+```bash
+pytest
+```
+
+The tests exercise the Flask API endpoints such as registration, login and
+message handling.

--- a/backend/app.py
+++ b/backend/app.py
@@ -56,7 +56,7 @@ api.add_resource(Login, '/api/login')
 api.add_resource(Messages, '/api/messages')
 api.add_resource(PublicKey, '/api/public_key/<string:username>')
 
-# Run the app
+# Run the development server only when executed directly.
 if __name__ == '__main__':
     # socketio.run enables WebSocket support alongside the Flask app
     socketio.run(app, debug=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -25,6 +25,7 @@ class User(db.Model):
 
     @staticmethod
     def generate_key_pair():
+        """Return a new RSA private key and the corresponding public key PEM."""
         private_key = rsa.generate_private_key(
             public_exponent=65537,
             key_size=2048,

--- a/backend/resources.py
+++ b/backend/resources.py
@@ -43,6 +43,8 @@ The encrypted private key, salt, and IV are then
 sent to the user encoded in base64.
 """
 class Register(Resource):
+    """Create a new user and return the encrypted private key."""
+
     def post(self):
         # Parse the request data
         data = user_parser.parse_args()
@@ -105,6 +107,8 @@ class Register(Resource):
         }, 201
 
 class Login(Resource):
+    """Authenticate a user and return a JWT access token."""
+
     def post(self):
         data = request.get_json()
 
@@ -123,15 +127,19 @@ class PublicKey(Resource):
 
     @jwt_required()
     def get(self, username):
+        """Fetch the PEM encoded public key for ``username``."""
         user = User.query.filter_by(username=username).first()
         if not user:
             return {"message": "User not found"}, 404
         return {"public_key": user.public_key_pem}
 
 class Messages(Resource):
+    """Retrieve or create encrypted chat messages."""
+
     # Retrieve all messages. Requires a valid JWT token.
     @jwt_required()
     def get(self):
+        """Return decrypted messages for the authenticated user."""
         messages = Message.query.all()
         message_list = [
             {
@@ -147,6 +155,7 @@ class Messages(Resource):
     # Send a new message. Rate limited via the limiter in app.py
     @jwt_required()
     def post(self):
+        """Store an encrypted message and broadcast it to clients."""
         data = message_parser.parse_args()
 
         encrypted_content = cipher_suite.encrypt(data["content"].encode()).decode()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+
+# These imports will fail if Flask and related dependencies are not installed.
+from backend.app import app, db
+from backend.models import User, Message
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def register_user(client, username='alice'):
+    data = {
+        'username': username,
+        'email': f'{username}@example.com',
+        'password': 'secret',
+    }
+    return client.post('/api/register', data=data)
+
+
+def login_user(client, username='alice'):
+    return client.post('/api/login', json={
+        'username': username,
+        'password': 'secret',
+    })
+
+
+def test_register_and_login(client):
+    resp = register_user(client)
+    assert resp.status_code == 201
+    payload = resp.get_json()
+    assert 'encrypted_private_key' in payload
+
+    resp = login_user(client)
+    assert resp.status_code == 200
+    assert 'access_token' in resp.get_json()
+
+
+def test_message_flow(client):
+    register_user(client, 'bob')
+    login = login_user(client, 'bob')
+    token = login.get_json()['access_token']
+    headers = {'Authorization': f'Bearer {token}'}
+
+    resp = client.post('/api/messages', data={'content': 'hello'}, headers=headers)
+    assert resp.status_code == 201
+
+    resp = client.get('/api/messages', headers=headers)
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert len(data['messages']) == 1


### PR DESCRIPTION
## Summary
- add instructions for running tests
- clarify when server runs in app factory
- document user key generation and API resources
- add pytest suite covering registration, login and message flows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f590d1a1083218ed28cec4fa9f29b