### PR TITLE
Improve client-side key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This secure messaging application consists of a frontend built with React and a 
 # Features
 - User registration and login
 - Asymmetric encryption using **RSA-OAEP** for message exchange
-- Symmetric encryption using **AES-256** in CBC mode for private key storage
+- Client-side private key storage
 - Key derivation using **PBKDF2**
 - Encrypted message storage
 - Rate limiting on message sending
@@ -21,16 +21,16 @@ This secure messaging application consists of a frontend built with React and a 
 # Frontend
 The frontend is built using React and consists of the following components:
 1. **LoginForm**: Handles user login by sending a request to the backend for authentication.
-2. **RegisterForm**: Handles user registration by sending user information to the backend, generating an RSA key pair, and storing the encrypted private key on the client-side.
+2. **RegisterForm**: Handles user registration by generating an RSA key pair, sending the public key to the backend, and storing the private key on the client.
 3. **Chat**: Provides an interface for users to send and receive encrypted messages. The component also handles message encryption and decryption.
 4. **UserAccount**: Displays the user account management interface.
 5. **App**: Sets up the application's routing and includes the navigation bar.
 
 # Backend
 The backend is built using Flask and consists of the following resources:
-1. **Register**: Handles user registration by saving user information, hashed passwords, and public keys to the database. It also returns the encrypted private key, salt, and IV to the frontend for storage.
+1. **Register**: Handles user registration by saving user information, hashed passwords, and the provided public key to the database. The private key remains on the client.
 2. **Login**: Handles user login by verifying the provided username and password, and returns a JWT access token if the credentials are valid.
-3. **Messages**: Handles fetching and storing messages in the database. Messages are encrypted before storage and decrypted before sending them to the frontend.
+3. **Messages**: Handles fetching and storing messages in the database. Messages are stored exactly as submitted by clients (already encrypted).
 The backend also includes rate limiting on message sending, JWT-based user authentication, and CORS configuration.
 
 # Setup

--- a/backend/resources.py
+++ b/backend/resources.py
@@ -1,29 +1,19 @@
 from flask_restful import Resource, reqparse
 from flask import request, jsonify
 from werkzeug.security import generate_password_hash, check_password_hash
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.padding import PKCS7
-from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
-from cryptography.hazmat.backends import default_backend
-from base64 import b64encode
 import os
 from models import User, Message
 from app import db, app, socketio
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
 import json
 
-# Fernet key for encryption
-FERNET_KEY = os.environ.get('FERNET_KEY') or Fernet.generate_key()
-cipher_suite = Fernet(FERNET_KEY)
 
 # Request parser for user registration
 user_parser = reqparse.RequestParser()
 user_parser.add_argument('username', required=True, help="Username is required.")
 user_parser.add_argument('email', required=True, help="Email is required.")
 user_parser.add_argument('password', required=True, help="Password is required.")
+user_parser.add_argument('publicKey', required=True, help="Public key is required.")
 
 # Request parser for messages
 message_parser = reqparse.RequestParser()
@@ -32,16 +22,6 @@ message_parser.add_argument('content', required=True, help="Content is required.
 # Token serializer (legacy).  JWT is now used instead of this custom mechanism.
 # s = Serializer(app.config['SECRET_KEY'], expires_in=3600)
 
-# The previous implementation relied on a custom token_required decorator that
-# used itsdangerous for token verification.  The project now leverages
-# Flask-JWT-Extended, so authentication decorators below use @jwt_required.
-
-"""
-The private key is encrypted using AES-256 in CBC mode, 
-with a key derived from the user's password using PBKDF2. 
-The encrypted private key, salt, and IV are then 
-sent to the user encoded in base64.
-"""
 class Register(Resource):
     def post(self):
         # Parse the request data
@@ -54,55 +34,13 @@ class Register(Resource):
 
         # Hash the password
         hashed_password = generate_password_hash(data['password'], method='sha256')
+        public_key_pem = data["publicKey"]
+        new_user = User(username=data["username"], email=data["email"], password_hash=hashed_password, public_key_pem=public_key_pem)
+        db.session.add(new_user)
+        db.session.commit()
+        return {"message": "User registered successfully."}, 201
 
-        # Generate key pair
-        private_key, public_key_pem = User.generate_key_pair()
 
-        # Encrypt the private key with the user's password
-        password = data['password'].encode()  # Encode the user's password as bytes
-        salt = os.urandom(16)                 # Generate a random salt (16 bytes)
-        
-        # Key Derivation Function (KDF) to derive a cryptographic key from the password using PBKDF2 with HMAC and SHA-256
-        kdf = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),  # Use SHA-256 hash algorithm
-            length=32,                  # Length of derived key (32 bytes)
-            salt=salt,                  # Salt for the KDF
-            iterations=100000,          # Number of iterations for the KDF
-            backend=default_backend()   # Cryptographic backend
-        )
-        key = kdf.derive(password)  # Derive the key using the user's password
-        
-        iv = os.urandom(16)  # Generate a random initialization vector (IV) for AES encryption (16 bytes)
-        
-        # Create a cipher object using AES encryption in CBC mode
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        encryptor = cipher.encryptor()  # Create an encryptor object from the cipher
-        
-        # Create a padder object for PKCS7 padding
-        padder = PKCS7(128).padder()
-        
-        # Pad the private key and convert it to bytes in PEM format
-        padded_private_key = padder.update(private_key.private_bytes(
-            encoding=Encoding.PEM,
-            format=PrivateFormat.PKCS8,
-            encryption_algorithm=NoEncryption()
-        )) + padder.finalize()
-        
-        # Encrypt the padded private key
-        encrypted_private_key = encryptor.update(padded_private_key) + encryptor.finalize()
-        
-        # Create a new user and add it to the database
-        new_user = User(username=data['username'], email=data['email'], password_hash=hashed_password, public_key_pem=public_key_pem)
-        db.session.add(new_user)  # Add the new user to the database session
-        db.session.commit()       # Commit the database transaction
-        
-        # Send encrypted private key and encryption details to the user
-        return {
-            "message": "User registered successfully.",                            # Confirmation message
-            "encrypted_private_key": b64encode(encrypted_private_key).decode(),     # Base64-encoded encrypted private key
-            "salt": b64encode(salt).decode(),                                      # Base64-encoded salt
-            "iv": b64encode(iv).decode()                                           # Base64-encoded IV
-        }, 201
 
 class Login(Resource):
     def post(self):
@@ -136,7 +74,7 @@ class Messages(Resource):
         message_list = [
             {
                 "id": msg.id,
-                "content": cipher_suite.decrypt(msg.content.encode()).decode(),
+                "content": msg.content,
                 "timestamp": msg.timestamp,
                 "user_id": msg.user_id,
             }
@@ -149,7 +87,7 @@ class Messages(Resource):
     def post(self):
         data = message_parser.parse_args()
 
-        encrypted_content = cipher_suite.encrypt(data["content"].encode()).decode()
+        encrypted_content = data["content"]
 
         current_user_id = get_jwt_identity()
         new_message = Message(content=encrypted_content, user_id=current_user_id)

--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -76,6 +76,8 @@ function Chat() {
       { id: 1, text: 'Welcome to PrivateLine!', type: 'received' }
     ]);
     const [socket, setSocket] = useState(null);
+    const [privateKey, setPrivateKey] = useState(null);
+    const privateKeyRef = React.useRef(null);
 
     // Cache for recipient public keys.  In a real app this might live in a
     // Redux store or other global cache.
@@ -86,12 +88,39 @@ function Chat() {
       const s = io(process.env.REACT_APP_API_URL || 'http://localhost:5000');
       setSocket(s);
 
+      // Load the stored private key for decrypting messages
+      (async () => {
+        const stored = localStorage.getItem('private_key');
+        if (stored) {
+          const keyBuffer = new Uint8Array(Buffer.from(stored, 'base64'));
+          const key = await window.crypto.subtle.importKey(
+            'pkcs8',
+            keyBuffer,
+            { name: 'RSA-OAEP', hash: 'SHA-256' },
+            true,
+            ['decrypt']
+          );
+          setPrivateKey(key);
+          privateKeyRef.current = key;
+        }
+      })();
+
       // Append new messages received from the server
       s.on('new_message', (payload) => {
-        setMessages((prev) => [
-          ...prev,
-          { id: Date.now(), text: payload.content, type: 'received' },
-        ]);
+        const key = privateKeyRef.current;
+        if (key) {
+          decryptMessage(key, payload.content).then((plain) => {
+            setMessages((prev) => [
+              ...prev,
+              { id: Date.now(), text: plain, type: 'received' },
+            ]);
+          });
+        } else {
+          setMessages((prev) => [
+            ...prev,
+            { id: Date.now(), text: payload.content, type: 'received' },
+          ]);
+        }
       });
 
       return () => s.disconnect();
@@ -120,7 +149,7 @@ function Chat() {
           content: encryptedMessage,
         });
 
-        if (response.status === 200) {
+        if (response.status === 201) {
           // Append the sent message locally
           setMessages([...messages, { id: Date.now(), text: message, type: 'sent' }]);
           setMessage('');

--- a/frontend/src/components/RegisterForm.js
+++ b/frontend/src/components/RegisterForm.js
@@ -46,11 +46,16 @@ function RegisterForm() {
         publicKey: publicKeyPem,
       });
 
-      if (response.status === 200) {
-        // Save the private key securely on the user's device
-        // Implement a secure storage mechanism, e.g., IndexedDB
+      if (response.status === 201) {
+        // Export the private key and store it for later message decryption
+        const exportedPrivateKey = await window.crypto.subtle.exportKey(
+          'pkcs8',
+          keyPair.privateKey
+        );
+        const privateKeyPem = Buffer.from(exportedPrivateKey).toString('base64');
+        localStorage.setItem('private_key', privateKeyPem);
 
-        // Redirect to the login page or another appropriate page
+        // TODO: redirect to login or chat page
       } else {
         // Handle registration errors
       }


### PR DESCRIPTION
## Summary
- update README to reflect new registration flow
- store public key during registration and keep private key on the client
- simplify backend registration resource and message storage
- decrypt messages using stored private key on the frontend

## Testing
- `python -m py_compile backend/app.py backend/resources.py backend/models.py`