### PR TITLE
Centralize key generation on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This secure messaging application consists of a frontend built with React and a 
 # Frontend
 The frontend is built using React and consists of the following components:
 1. **LoginForm**: Handles user login by sending a request to the backend for authentication.
-2. **RegisterForm**: Handles user registration by sending user information to the backend, generating an RSA key pair, and storing the encrypted private key on the client-side.
+2. **RegisterForm**: Handles user registration by sending user information to the backend and storing the encrypted private key returned by the server.
 3. **Chat**: Provides an interface for users to send and receive encrypted messages. The component also handles message encryption and decryption.
 4. **UserAccount**: Displays the user account management interface.
 5. **App**: Sets up the application's routing, theme provider and navigation bar.

--- a/backend/app.py
+++ b/backend/app.py
@@ -45,7 +45,7 @@ api = Api(app)
 jwt = JWTManager(app)
 
 # Import resources after initializing app components to avoid circular imports
-from resources import Register, Login, Messages, PublicKey
+from .resources import Register, Login, Messages, PublicKey
 
 # Apply rate limiting on the messages resource
 limiter.limit("50/minute")(Messages)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from app import db
+from .app import db
 from datetime import datetime
 from sqlalchemy.ext.hybrid import hybrid_property
 from cryptography.hazmat.primitives import serialization

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,8 @@ Flask==2.1.1
 Flask-RESTful==0.3.10
 Flask-SQLAlchemy==2.5.1
 Flask-Migrate==3.1.0
-Flask-CORS==3.1.1
+Flask-CORS==3.0.10
+SQLAlchemy==1.4.54
 Flask-Limiter==1.4
 Flask-JWT-Extended==4.3.1
 Flask-SocketIO==5.3.2

--- a/frontend/src/components/RegisterForm.js
+++ b/frontend/src/components/RegisterForm.js
@@ -1,24 +1,9 @@
-// Generates a key pair for each user during registration. 
-// The public key is sent to the server, and the private key should be securely stored on the user's device. 
+// Registration form.  Keys are generated on the server and the encrypted
+// private key is returned to the client.
 // The form itself includes input fields for the username, email, and password, as well as a submit button
 import React, { useState } from 'react';
 import { Box, Button, TextField, Typography } from '@mui/material';
 import api from '../api';
-
-async function generateKeyPair() {
-  const keyPair = await window.crypto.subtle.generateKey(
-    {
-      name: 'RSA-OAEP',
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: 'SHA-256',
-    },
-    true,
-    ['encrypt', 'decrypt']
-  );
-
-  return keyPair;
-}
 
 function RegisterForm() {
   const [username, setUsername] = useState('');
@@ -28,23 +13,11 @@ function RegisterForm() {
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    // Generate key pair for the user
-    const keyPair = await generateKeyPair();
-
-    // Export the public key to PEM format
-    const exportedPublicKey = await window.crypto.subtle.exportKey(
-      'spki',
-      keyPair.publicKey
-    );
-    const publicKeyPem = Buffer.from(exportedPublicKey).toString('base64');
-
-    // Send the registration data to the server
     try {
       const response = await api.post('/api/register', {
         username,
         email,
         password,
-        publicKey: publicKeyPem,
       });
 
       if (response.status === 200) {


### PR DESCRIPTION
## Summary
- remove client-side keypair generation
- adjust backend routes to accept form or JSON input
- fix JWT identity handling and timestamp serialization
- pin SQLAlchemy and correct imports

## Testing
- `pytest -q`