### PR TITLE
Improve setup instructions and frontend dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Example environment configuration for PrivateLine
 # Copy this file to .env and provide real values before running the app.
 JWT_SECRET_KEY=your-secret-key
+# Base64-encoded 32 byte key for encrypting stored messages
+# AES_KEY=$(openssl rand -base64 32)
+#AES_KEY=
 #DATABASE_URI=sqlite:///secure_messaging.db
 #FERNET_KEY=optional-random-key
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ The backend also includes rate limiting on message sending, JWT-based user authe
 # Setup
 To run the application, follow these steps:
 1. Clone the repository.
-2. Copy `.env.example` to `.env` and provide values for `JWT_SECRET_KEY` and optional `DATABASE_URI`.
+2. Copy `.env.example` to `.env` and provide values for the following variables:
+   * `JWT_SECRET_KEY` – key used for JWT signatures.
+   * `AES_KEY` – base64 encoded 32 byte key used to encrypt persisted messages. A convenient way to generate one is `openssl rand -base64 32`.
+   * Optional `DATABASE_URI` if you want to use a database other than the default SQLite file.
 3. Install backend dependencies with `pip install -r backend/requirements.txt`.
 4. Install frontend dependencies with `npm install` inside the `frontend` directory.
-5. Start the backend with `python backend/app.py` and the frontend with your preferred React tooling.
+5. Start the backend with `python backend/app.py` and the frontend with `npm start`.
 6. Open a browser and navigate to the frontend's URL to use the application.
 
 ## Running Tests

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "@mui/icons-material": "^5.14.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^5.3.4"
+    "react-router-dom": "^5.3.4",
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- document AES_KEY usage and example generation in `.env.example`
- expand README setup steps with AES_KEY and `npm start`
- add `react-scripts` to frontend package.json

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`