### PR TITLE
Handle key storage with IndexedDB

### DIFF
--- a/frontend/src/components/RegisterForm.js
+++ b/frontend/src/components/RegisterForm.js
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { Box, Button, TextField, Typography } from '@mui/material';
 import api from '../api';
+import { saveKeyMaterial } from '../utils/secureStore';
 
 function RegisterForm() {
   const [username, setUsername] = useState('');
@@ -20,9 +21,9 @@ function RegisterForm() {
         password,
       });
 
-      if (response.status === 200) {
-        // Save the private key securely on the user's device
-        // Implement a secure storage mechanism, e.g., IndexedDB
+      if (response.status === 201) {
+        const { encrypted_private_key, salt, nonce } = response.data;
+        await saveKeyMaterial({ encrypted_private_key, salt, nonce });
 
         // Redirect to the login page or another appropriate page
       } else {

--- a/frontend/src/utils/secureStore.js
+++ b/frontend/src/utils/secureStore.js
@@ -1,0 +1,39 @@
+const DB_NAME = 'privateline';
+const DB_VERSION = 1;
+const STORE_NAME = 'keyMaterial';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveKeyMaterial({ encrypted_private_key, salt, nonce }) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.put({ encrypted_private_key, salt, nonce }, 'material');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(req.error);
+  });
+}
+
+export async function loadKeyMaterial() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.get('material');
+    req.onsuccess = () => resolve(req.result || {});
+    req.onerror = () => reject(req.error);
+  });
+}


### PR DESCRIPTION
## Summary
- save encrypted private key details returned during registration using IndexedDB
- add helper utilities for saving and loading from IndexedDB
- decrypt stored key on login and keep PEM in session storage
- import the stored private key in Chat and try to decrypt incoming messages

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa0e08f648321a61aca9cca5076d1