### PR TITLE
Enhance iOS app with persistence and real-time updates

### DIFF
--- a/ios/PrivateLine/ChatView.swift
+++ b/ios/PrivateLine/ChatView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ChatView: View {
+    @StateObject var viewModel: ChatViewModel
+
+    var body: some View {
+        VStack {
+            List(viewModel.messages) { msg in
+                Text(msg.content)
+            }
+            HStack {
+                TextField("Message", text: $viewModel.input)
+                Button("Send") { Task { await viewModel.send() } }
+            }
+        }
+        .onAppear { Task { await viewModel.load() } }
+        .onDisappear { viewModel.disconnect() }
+        .padding()
+    }
+}

--- a/ios/PrivateLine/ChatViewModel.swift
+++ b/ios/PrivateLine/ChatViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var messages: [Message] = []
+    @Published var input = ""
+
+    private let api: APIService
+    private let socket = WebSocketService()
+
+    init(api: APIService) {
+        self.api = api
+    }
+
+    func load() async {
+        do {
+            messages = try await api.fetchMessages()
+            if let token = api.authToken {
+                socket.connect(token: token)
+            }
+            socket.$messages.assign(to: &$messages)
+        } catch {
+            messages = []
+        }
+    }
+
+    func send() async {
+        do {
+            let msg = try await api.sendMessage(input)
+            messages.append(msg)
+            input = ""
+        } catch {
+            // ignore for now
+        }
+    }
+
+    func disconnect() {
+        socket.disconnect()
+    }
+}

--- a/ios/PrivateLine/ContentView.swift
+++ b/ios/PrivateLine/ContentView.swift
@@ -1,64 +1,23 @@
 import SwiftUI
 
-/// Main screen that displays either the login form or the chat view
-/// depending on the authentication state.
+/// Root view that displays either the login screen or chat depending on auth state.
 struct ContentView: View {
-    /// Service used to communicate with the backend.
     @StateObject private var api = APIService()
-    /// Username entered on the login form.
-    @State private var username = ""
-    /// Password entered on the login form.
-    @State private var password = ""
-    /// Current message text in the chat box.
-    @State private var message = ""
-    /// List of messages fetched from the backend.
-    @State private var messages: [Message] = []
 
     var body: some View {
         NavigationView {
-            VStack {
-                if api.isAuthenticated {
-                    // Chat view shown after a successful login
-                    List(messages) { msg in
-                        Text(msg.content)
-                    }
-                    HStack {
-                        TextField("Message", text: $message)
-                        Button("Send") {
-                            api.sendMessage(message) { fetched in
-                                if let fetched = fetched {
-                                    messages.append(fetched)
-                                }
-                            }
-                            // Clear the input after sending
-                            message = ""
-                        }
-                    }
-                } else {
-                    // Login form displayed when not authenticated
-                    TextField("Username", text: $username)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                    SecureField("Password", text: $password)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                    Button("Login") {
-                        api.login(username: username, password: password) { success in
-                            if success {
-                                api.fetchMessages { fetched in
-                                    messages = fetched
-                                }
-                            }
-                        }
-                    }
-                }
+            if api.isAuthenticated {
+                ChatView(viewModel: ChatViewModel(api: api))
+                    .navigationTitle("PrivateLine")
+            } else {
+                LoginView(viewModel: LoginViewModel(api: api))
+                    .navigationTitle("PrivateLine")
             }
-            .padding()
-            .navigationTitle("PrivateLine")
         }
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
-    /// Render a preview for Xcode's canvas
     static var previews: some View {
         ContentView()
     }

--- a/ios/PrivateLine/CryptoManager.swift
+++ b/ios/PrivateLine/CryptoManager.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CryptoKit
+
+/// Placeholder crypto manager. It currently performs simple pass-through
+/// operations but is structured for future end-to-end encryption support.
+struct CryptoManager {
+    static func encryptMessage(_ message: String) throws -> Data {
+        // Placeholder: return plaintext data for now
+        return Data(message.utf8)
+    }
+
+    static func decryptMessage(_ data: Data) throws -> String {
+        // Placeholder: simply decode UTF-8 for now
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/ios/PrivateLine/Info.plist
+++ b/ios/PrivateLine/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>BackendBaseURL</key>
+    <string>http://localhost:5000/api</string>
+    <key>WebSocketURL</key>
+    <string>ws://localhost:5000/socket.io/?transport=websocket</string>
+</dict>
+</plist>

--- a/ios/PrivateLine/KeychainService.swift
+++ b/ios/PrivateLine/KeychainService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Security
+
+/// Simple helper for storing and retrieving values from the Keychain.
+struct KeychainService {
+    private static let tokenKey = "PrivateLineToken"
+
+    static func saveToken(_ token: String) {
+        if let data = token.data(using: .utf8) {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: tokenKey,
+                kSecValueData as String: data
+            ]
+            SecItemDelete(query as CFDictionary)
+            SecItemAdd(query as CFDictionary, nil)
+        }
+    }
+
+    static func loadToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: tokenKey,
+            kSecReturnData as String: kCFBooleanTrue as Any,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func removeToken() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: tokenKey
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/PrivateLine/LoginView.swift
+++ b/ios/PrivateLine/LoginView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct LoginView: View {
+    @StateObject var viewModel: LoginViewModel
+
+    var body: some View {
+        VStack {
+            if viewModel.isRegistering {
+                TextField("Username", text: $viewModel.username)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                TextField("Email", text: $viewModel.email)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                SecureField("Password", text: $viewModel.password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Register") {
+                    Task { await viewModel.register() }
+                }
+                Button("Back to Login") { viewModel.isRegistering = false }
+            } else {
+                TextField("Username", text: $viewModel.username)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                SecureField("Password", text: $viewModel.password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Login") { Task { await viewModel.login() } }
+                Button("Create Account") { viewModel.isRegistering = true }
+            }
+            if let error = viewModel.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
+        .padding()
+    }
+}

--- a/ios/PrivateLine/LoginViewModel.swift
+++ b/ios/PrivateLine/LoginViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Combine
+
+@MainActor
+final class LoginViewModel: ObservableObject {
+    @Published var username = ""
+    @Published var password = ""
+    @Published var email = ""
+    @Published var isRegistering = false
+    @Published var errorMessage: String?
+
+    private let api: APIService
+
+    init(api: APIService) {
+        self.api = api
+    }
+
+    func login() async {
+        do {
+            try await api.login(username: username, password: password)
+        } catch {
+            errorMessage = "Login failed"
+        }
+    }
+
+    func register() async {
+        do {
+            try await api.register(username: username, email: email, password: password)
+            isRegistering = false
+        } catch {
+            errorMessage = "Registration failed"
+        }
+    }
+}

--- a/ios/PrivateLine/WebSocketService.swift
+++ b/ios/PrivateLine/WebSocketService.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Handles real-time message updates using URLSession WebSocket.
+class WebSocketService: ObservableObject {
+    private var task: URLSessionWebSocketTask?
+    @Published var messages: [Message] = []
+
+    func connect(token: String) {
+        guard let urlString = Bundle.main.object(forInfoDictionaryKey: "WebSocketURL") as? String,
+              let url = URL(string: urlString) else { return }
+        var request = URLRequest(url: url)
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        task = URLSession.shared.webSocketTask(with: request)
+        task?.resume()
+        listen()
+    }
+
+    private func listen() {
+        task?.receive { [weak self] result in
+            switch result {
+            case .failure:
+                break
+            case .success(let message):
+                if case .string(let text) = message,
+                   let data = text.data(using: .utf8),
+                   let msg = try? JSONDecoder().decode(Message.self, from: data) {
+                    DispatchQueue.main.async {
+                        self?.messages.append(msg)
+                    }
+                }
+            }
+            self?.listen()
+        }
+    }
+
+    func disconnect() {
+        task?.cancel(with: .goingAway, reason: nil)
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,11 +1,11 @@
 # iOS Client (SwiftUI)
 
-This directory contains a minimal SwiftUI client for the PrivateLine backend. It demonstrates basic user authentication and message exchange with the Flask API.
+This directory contains a lightweight SwiftUI client for the PrivateLine backend. It now persists credentials in the Keychain, supports registration and displays messages in real time via WebSockets.
 
 ## Getting Started
 
 1. Open the `ios` folder in Xcode.
-2. Ensure the Flask backend is running on `http://localhost:5000`.
+2. Modify `Info.plist` if your backend does not run on `localhost`. The keys `BackendBaseURL` and `WebSocketURL` control the REST and WebSocket endpoints.
 3. Build and run the app in the iOS simulator.
 
-The app includes a simple login screen and a chat view. After logging in, messages can be fetched and sent using the API service.
+After launching the app you can create an account or log in. Messages are fetched using async/await and appear instantly when delivered over the WebSocket connection.


### PR DESCRIPTION
## Summary
- add Info.plist configuration for backend and WebSocket URLs
- store JWT token securely in Keychain
- migrate APIService to async/await and load base URL from Info.plist
- add CryptoManager placeholder for future encryption
- add WebSocketService and view models for MVVM
- split UI into LoginView and ChatView
- update README with new instructions

## Testing
- `pytest -q`