### PR TITLE
Use base64 for encrypted messages

### DIFF
--- a/ios/PrivateLine/APIService.swift
+++ b/ios/PrivateLine/APIService.swift
@@ -111,8 +111,10 @@ class APIService: ObservableObject {
         var request = URLRequest(url: baseURL.appendingPathComponent("messages"))
         request.httpMethod = "POST"
         request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        // Encrypt locally and send Base64 ciphertext to the backend
         let encrypted = try CryptoManager.encryptMessage(content)
-        request.httpBody = "content=\(String(decoding: encrypted, as: UTF8.self))".data(using: .utf8)
+        let b64 = encrypted.base64EncodedString()
+        request.httpBody = "content=\(b64)".data(using: .utf8)
         let (data, _) = try await session.data(for: request)
         return try JSONDecoder().decode(Message.self, from: data)
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,20 +89,23 @@ def test_message_flow(client):
     token = login.get_json()['access_token']
     headers = {'Authorization': f'Bearer {token}'}
 
-    resp = client.post('/api/messages', data={'content': 'hello'}, headers=headers)
+    b64 = base64.b64encode(b'hello').decode()
+    resp = client.post('/api/messages', data={'content': b64}, headers=headers)
     assert resp.status_code == 201
 
     resp = client.get('/api/messages', headers=headers)
     data = resp.get_json()
     assert resp.status_code == 200
     assert len(data['messages']) == 1
+    assert data['messages'][0]['content'] == b64
 
 
 def test_message_privacy(client):
     register_user(client, 'eve')
     token_eve = login_user(client, 'eve').get_json()['access_token']
     headers_eve = {'Authorization': f'Bearer {token_eve}'}
-    client.post('/api/messages', data={'content': 'secret'}, headers=headers_eve)
+    encoded = base64.b64encode(b'secret').decode()
+    client.post('/api/messages', data={'content': encoded}, headers=headers_eve)
 
     register_user(client, 'mallory')
     token_mallory = login_user(client, 'mallory').get_json()['access_token']


### PR DESCRIPTION
## Summary
- encode outbound ciphertext in the iOS API client
- decode inbound ciphertext on message POST
- return base64 ciphertext to clients on message GET
- update tests for base64 workflow

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`