### PR TITLE
Enable RSA encryption in chat

### DIFF
--- a/frontend/src/components/__tests__/Chat.test.js
+++ b/frontend/src/components/__tests__/Chat.test.js
@@ -16,7 +16,9 @@ it('fetches existing messages and shows websocket updates', async () => {
 
   render(<Chat />);
 
-  expect(api.get).toHaveBeenCalledWith('/api/messages');
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/api/messages');
+  });
 
   // existing message from API should appear
   await screen.findByText('hello');


### PR DESCRIPTION
## Summary
- encrypt messages in Chat.js before sending
- decrypt incoming websocket messages
- fetch messages after decrypting with stored private key
- adjust Chat test to wait for initial API call

## Testing
- `pytest -q`
- `CI=true npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840421f76208321ae1d7090f03820c8