### PR TITLE
Implement RSA encryption in iOS client

### DIFF
--- a/ios/PrivateLine/ChatViewModel.swift
+++ b/ios/PrivateLine/ChatViewModel.swift
@@ -5,6 +5,7 @@ import Combine
 final class ChatViewModel: ObservableObject {
     @Published var messages: [Message] = []
     @Published var input = ""
+    @Published var recipient = "bob"
 
     private let api: APIService
     private let socket = WebSocketService()
@@ -35,7 +36,8 @@ final class ChatViewModel: ObservableObject {
 
     func send() async {
         do {
-            let msg = try await api.sendMessage(input)
+            try await api.sendMessage(input, to: recipient)
+            let msg = Message(id: Int(Date().timeIntervalSince1970), content: input)
             messages.append(msg)
             MessageStore.save(messages)
             input = ""

--- a/ios/PrivateLine/KeychainService.swift
+++ b/ios/PrivateLine/KeychainService.swift
@@ -7,7 +7,7 @@ struct KeychainService {
     private static let tokenKey = "PrivateLineToken"
 
     /// Generic helper to save arbitrary data in the keychain under ``account``.
-    private static func save(_ account: String, data: Data) {
+    static func save(_ account: String, data: Data) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: account,
@@ -18,7 +18,7 @@ struct KeychainService {
     }
 
     /// Generic helper to load arbitrary data from the keychain.
-    private static func loadData(account: String, context: LAContext? = nil) -> Data? {
+    static func loadData(account: String, context: LAContext? = nil) -> Data? {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: account,

--- a/ios/PrivateLine/WebSocketService.swift
+++ b/ios/PrivateLine/WebSocketService.swift
@@ -23,7 +23,10 @@ class WebSocketService: ObservableObject {
             case .success(let message):
                 if case .string(let text) = message,
                    let data = text.data(using: .utf8),
-                   let msg = try? JSONDecoder().decode(Message.self, from: data) {
+                   let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let b64 = payload["content"] as? String,
+                   let plaintext = try? CryptoManager.decryptRSA(b64) {
+                    let msg = Message(id: Int(Date().timeIntervalSince1970), content: plaintext)
                     DispatchQueue.main.async {
                         self?.messages.append(msg)
                     }


### PR DESCRIPTION
## Summary
- expose generic save/load helpers in `KeychainService`
- extend `CryptoManager` with RSA key handling
- fetch and cache public keys and encrypt messages with RSA in `APIService`
- decrypt incoming messages and update send logic in `ChatViewModel` and `WebSocketService`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`