### PR TITLE
Add private messaging recipient support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,7 +14,7 @@ from flask_jwt_extended import (
     verify_jwt_in_request,
     get_jwt,
 )
-from flask_socketio import SocketIO, disconnect
+from flask_socketio import SocketIO, disconnect, join_room
 from dotenv import load_dotenv
 
 # Load environment variables from a .env file if present.  This keeps
@@ -89,6 +89,8 @@ from .resources import (
 def socket_connect():
     try:
         verify_jwt_in_request()
+        user_id = get_jwt_identity()
+        join_room(str(user_id))
     except Exception:
         app.logger.warning("WebSocket connection rejected due to missing or invalid token")
         disconnect()

--- a/backend/models.py
+++ b/backend/models.py
@@ -46,4 +46,11 @@ class Message(db.Model):
     content = db.Column(db.String(1000), nullable=False)
     nonce = db.Column(db.String(24), nullable=False)
     timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow)
+    # ``user_id`` historically referenced the owner of the message.  To support
+    # private messaging between two users while maintaining backward
+    # compatibility, the original column remains but new ``sender_id`` and
+    # ``recipient_id`` fields explicitly store both parties.  ``user_id`` is set
+    # to the sender for new messages but is otherwise unused.
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)


### PR DESCRIPTION
## Summary
- add `sender_id` and `recipient_id` columns to `Message`
- store and return sender/recipient data
- broadcast WebSocket messages only to the recipient
- require a recipient when sending messages
- extend tests for new message flow and add a test for unknown recipients

## Testing
- `pytest -q`