### PR TITLE
Implement key fingerprinting and pinned key verification

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,7 @@ from .resources import (
     Login,
     Messages,
     PublicKey,
+    PinnedKeys,
     AccountSettings,
     RefreshToken,
     RevokeToken,
@@ -103,6 +104,7 @@ api.add_resource(Register, '/api/register')
 api.add_resource(Login, '/api/login')
 api.add_resource(Messages, '/api/messages')
 api.add_resource(PublicKey, '/api/public_key/<string:username>')
+api.add_resource(PinnedKeys, '/api/pinned_keys')
 api.add_resource(AccountSettings, '/api/account-settings')
 api.add_resource(RefreshToken, '/api/refresh')
 api.add_resource(RevokeToken, '/api/revoke')

--- a/backend/models.py
+++ b/backend/models.py
@@ -54,3 +54,13 @@ class Message(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+
+class PinnedKey(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    username = db.Column(db.String(64), nullable=False)
+    fingerprint = db.Column(db.String(64), nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'username', name='uix_user_pinned'),
+    )

--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -59,6 +59,15 @@ function LoginForm() {
       if (response.status === 200) {
         // Store the received JWT so it can be attached to future requests
         localStorage.setItem('access_token', response.data.access_token);
+
+        try {
+          const pkResp = await api.get('/api/pinned_keys');
+          if (pkResp.status === 200) {
+            localStorage.setItem('pinned_keys', JSON.stringify(pkResp.data.pinned_keys || []));
+          }
+        } catch (e) {
+          console.error('Failed to fetch pinned keys', e);
+        }
         
         try {
           const material = await loadKeyMaterial();

--- a/frontend/src/components/RegisterForm.js
+++ b/frontend/src/components/RegisterForm.js
@@ -30,8 +30,9 @@ function RegisterForm() {
       });
 
       if (response.status === 201) {
-        const { encrypted_private_key, salt, nonce } = response.data;
-        await saveKeyMaterial({ encrypted_private_key, salt, nonce });
+        const { encrypted_private_key, salt, nonce, fingerprint } = response.data;
+        await saveKeyMaterial({ encrypted_private_key, salt, nonce, fingerprint });
+        alert(`Your key fingerprint is ${fingerprint}`);
         history.push('/login', { registered: true });
       } else {
         setError(response.data.message || 'Registration failed');

--- a/frontend/src/utils/secureStore.js
+++ b/frontend/src/utils/secureStore.js
@@ -1,5 +1,5 @@
 const DB_NAME = 'privateline';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = 'keyMaterial';
 
 function openDB() {
@@ -16,12 +16,12 @@ function openDB() {
   });
 }
 
-export async function saveKeyMaterial({ encrypted_private_key, salt, nonce }) {
+export async function saveKeyMaterial({ encrypted_private_key, salt, nonce, fingerprint }) {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
-    const req = store.put({ encrypted_private_key, salt, nonce }, 'material');
+    const req = store.put({ encrypted_private_key, salt, nonce, fingerprint }, 'material');
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(req.error);
   });

--- a/ios/PrivateLine/OnboardingView.swift
+++ b/ios/PrivateLine/OnboardingView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Simple introductory screen explaining privacy benefits.
 struct OnboardingView: View {
     @AppStorage("hasSeenOnboarding") private var hasSeen = false
+    private let fingerprint = CryptoManager.fingerprint()
 
     var body: some View {
         VStack(spacing: 20) {
@@ -11,6 +12,11 @@ struct OnboardingView: View {
             Text("All messages are encrypted locally before being sent. Your privacy is our priority.")
                 .multilineTextAlignment(.center)
                 .padding()
+            if let fp = fingerprint {
+                Text("Your key fingerprint: \(fp)")
+                    .font(.footnote)
+                    .padding()
+            }
             Button("Get Started") {
                 hasSeen = true
             }


### PR DESCRIPTION
## Summary
- generate a SHA-256 fingerprint when registering
- display fingerprint in registration UIs
- store pinned key fingerprints server-side and expose `/api/pinned_keys`
- verify recipient keys in web and iOS clients
- show fingerprint on iOS onboarding view
- update tests for new fingerprint field and pinned keys endpoint

## Testing
- `pytest -q`