### PR TITLE
Add iOS unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r backend/requirements.txt
+      - run: pytest
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run iOS tests
+        run: xcodebuild -scheme PrivateLine-Package -destination 'platform=iOS Simulator,name=iPhone 14' test
+        working-directory: ios

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "PrivateLine",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(name: "PrivateLine", targets: ["PrivateLine"]),
+    ],
+    targets: [
+        .target(name: "PrivateLine", path: "PrivateLine"),
+        .testTarget(name: "PrivateLineTests", dependencies: ["PrivateLine"], path: "PrivateLineTests"),
+    ]
+)

--- a/ios/PrivateLine/WebSocketService.swift
+++ b/ios/PrivateLine/WebSocketService.swift
@@ -3,14 +3,19 @@ import Foundation
 /// Handles real-time message updates using URLSession WebSocket.
 class WebSocketService: ObservableObject {
     private var task: URLSessionWebSocketTask?
+    private let session: URLSession
     @Published var messages: [Message] = []
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
 
     func connect(token: String) {
         guard let urlString = Bundle.main.object(forInfoDictionaryKey: "WebSocketURL") as? String,
               let url = URL(string: urlString) else { return }
         var request = URLRequest(url: url)
         request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        task = URLSession.shared.webSocketTask(with: request)
+        task = session.webSocketTask(with: request)
         task?.resume()
         listen()
     }

--- a/ios/PrivateLineTests/CryptoManagerTests.swift
+++ b/ios/PrivateLineTests/CryptoManagerTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import PrivateLine
+
+final class CryptoManagerTests: XCTestCase {
+    func testEncryptDecryptMessage() throws {
+        let message = "Hello, world!"
+        let encrypted = try CryptoManager.encryptMessage(message)
+        let decrypted = try CryptoManager.decryptMessage(encrypted)
+        XCTAssertEqual(decrypted, message)
+    }
+}

--- a/ios/PrivateLineTests/WebSocketServiceTests.swift
+++ b/ios/PrivateLineTests/WebSocketServiceTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import PrivateLine
+
+final class MockWebSocketTask: URLSessionWebSocketTask {
+    var resumed = false
+    var cancelled = false
+    override func resume() { resumed = true }
+    override func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        cancelled = true
+    }
+}
+
+final class MockURLSession: URLSession {
+    let task = MockWebSocketTask()
+    private(set) var lastRequest: URLRequest?
+    override func webSocketTask(with request: URLRequest) -> URLSessionWebSocketTask {
+        lastRequest = request
+        return task
+    }
+}
+
+final class WebSocketServiceTests: XCTestCase {
+    func testConnectStartsTask() {
+        let session = MockURLSession()
+        let service = WebSocketService(session: session)
+        service.connect(token: "abc")
+        XCTAssertTrue(session.task.resumed)
+    }
+
+    func testDisconnectCancelsTask() {
+        let session = MockURLSession()
+        let service = WebSocketService(session: session)
+        service.connect(token: "abc")
+        service.disconnect()
+        XCTAssertTrue(session.task.cancelled)
+    }
+}


### PR DESCRIPTION
## Summary
- add Package.swift in ios to build Swift sources and tests
- inject URLSession into WebSocketService for testability
- add CryptoManager and WebSocketService unit tests
- run backend and iOS tests in GitHub Actions

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `swift test --package-path ios` *(fails: no such module 'LocalAuthentication')*