### PR TITLE
Implement group messaging and file attachments

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,10 @@ from .resources import (
     Login,
     Messages,
     PublicKey,
+    Groups,
+    GroupMessages,
+    FileUpload,
+    FileDownload,
     PinnedKeys,
     AccountSettings,
     RefreshToken,
@@ -93,6 +97,10 @@ def socket_connect():
         verify_jwt_in_request()
         user_id = get_jwt_identity()
         join_room(str(user_id))
+        from .models import GroupMember
+        groups = GroupMember.query.filter_by(user_id=user_id).all()
+        for g in groups:
+            join_room(str(g.group_id))
     except Exception:
         app.logger.warning("WebSocket connection rejected due to missing or invalid token")
         disconnect()
@@ -105,6 +113,10 @@ api.add_resource(Register, '/api/register')
 api.add_resource(Login, '/api/login')
 api.add_resource(Messages, '/api/messages')
 api.add_resource(PublicKey, '/api/public_key/<string:username>')
+api.add_resource(Groups, '/api/groups')
+api.add_resource(GroupMessages, '/api/groups/<int:group_id>/messages')
+api.add_resource(FileUpload, '/api/files')
+api.add_resource(FileDownload, '/api/files/<int:file_id>')
 api.add_resource(PinnedKeys, '/api/pinned_keys')
 api.add_resource(AccountSettings, '/api/account-settings')
 api.add_resource(RefreshToken, '/api/refresh')

--- a/backend/models.py
+++ b/backend/models.py
@@ -41,6 +41,23 @@ class User(db.Model):
         return private_key, public_key_pem
 
 
+class Group(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(64), unique=True, nullable=False)
+
+
+class GroupMember(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    group_id = db.Column(db.Integer, db.ForeignKey('group.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+
+class File(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(256), nullable=False)
+    data = db.Column(db.LargeBinary, nullable=False)
+
+
 class Message(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.String(1000), nullable=False)
@@ -53,7 +70,9 @@ class Message(db.Model):
     # to the sender for new messages but is otherwise unused.
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    group_id = db.Column(db.Integer, db.ForeignKey('group.id'))
+    file_id = db.Column(db.Integer, db.ForeignKey('file.id'))
 
 
 class PinnedKey(db.Model):

--- a/ios/PrivateLine/ChatView.swift
+++ b/ios/PrivateLine/ChatView.swift
@@ -2,16 +2,49 @@ import SwiftUI
 
 struct ChatView: View {
     @StateObject var viewModel: ChatViewModel
+    @State private var showPicker = false
 
     var body: some View {
         VStack {
+            Picker("Conversation", selection: Binding(
+                get: { viewModel.selectedGroup == nil ? viewModel.recipient : "g\(viewModel.selectedGroup!)" },
+                set: { val in
+                    if val.hasPrefix("g") {
+                        viewModel.selectedGroup = Int(val.dropFirst())
+                    } else {
+                        viewModel.selectedGroup = nil
+                        viewModel.recipient = val
+                    }
+                    Task { await viewModel.load() }
+                })) {
+                ForEach(["alice","bob","carol"], id: \ .self) { u in
+                    Text(u).tag(u)
+                }
+                ForEach(viewModel.groups) { g in
+                    Text(g.name).tag("g\(g.id)")
+                }
+            }
+            .pickerStyle(MenuPickerStyle())
             List(viewModel.messages) { msg in
-                Text(msg.content)
+                HStack {
+                    Text(msg.content)
+                    if let fid = msg.file_id {
+                        Link("attachment", destination: URL(string: "\(viewModel.api.baseURLString)/files/\(fid)")!)
+                    }
+                }
                     .accessibilityLabel("Message: \(msg.content)")
             }
             HStack {
                 TextField("Message", text: $viewModel.input)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Attach") {
+                    showPicker = true
+                }
+                .fileImporter(isPresented: $showPicker, allowedContentTypes: [.data]) { result in
+                    if case let .success(url) = result, let data = try? Data(contentsOf: url) {
+                        viewModel.attachment = data
+                    }
+                }
                 Button(action: { Task { await viewModel.send() } }) {
                     Image(systemName: "paperplane.fill")
                 }

--- a/ios/PrivateLine/Message.swift
+++ b/ios/PrivateLine/Message.swift
@@ -6,4 +6,10 @@ struct Message: Identifiable, Decodable {
     let id: Int
     /// Decrypted text content.
     let content: String
+    let file_id: Int?
+}
+
+struct Group: Identifiable, Decodable {
+    let id: Int
+    let name: String
 }

--- a/ios/PrivateLine/WebSocketService.swift
+++ b/ios/PrivateLine/WebSocketService.swift
@@ -31,7 +31,8 @@ class WebSocketService: ObservableObject {
                    let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let b64 = payload["content"] as? String,
                    let plaintext = try? CryptoManager.decryptRSA(b64) {
-                    let msg = Message(id: Int(Date().timeIntervalSince1970), content: plaintext)
+                    let fid = payload["file_id"] as? Int
+                    let msg = Message(id: Int(Date().timeIntervalSince1970), content: plaintext, file_id: fid)
                     DispatchQueue.main.async {
                         self?.messages.append(msg)
                     }


### PR DESCRIPTION
## Summary
- add database models for groups and files
- expose group, group message, and file endpoints
- allow group conversations and attachments in the web chat
- mirror groups and attachments in the iOS client
- cover groups and file uploads with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ffc9ded083219834b1aee87949bb