### PR TITLE
Add message signatures

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -45,6 +45,7 @@ class Message(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.String(1000), nullable=False)
     nonce = db.Column(db.String(24), nullable=False)
+    signature = db.Column(db.Text, nullable=False)
     timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow)
     # ``user_id`` historically referenced the owner of the message.  To support
     # private messaging between two users while maintaining backward

--- a/frontend/src/components/__tests__/Chat.test.js
+++ b/frontend/src/components/__tests__/Chat.test.js
@@ -14,6 +14,7 @@ beforeAll(() => {
     subtle: {
       importKey: jest.fn().mockResolvedValue('key'),
       encrypt: jest.fn().mockResolvedValue(new ArrayBuffer(1)),
+      sign: jest.fn().mockResolvedValue(new ArrayBuffer(1)),
     },
   };
   if (!global.TextEncoder) {

--- a/ios/PrivateLine/APIService.swift
+++ b/ios/PrivateLine/APIService.swift
@@ -170,7 +170,9 @@ class APIService: ObservableObject {
         }
         let encrypted = try CryptoManager.encryptRSA(content, publicKeyPem: publicKeyPem)
         let b64 = encrypted.base64EncodedString()
-        request.httpBody = "content=\(b64)".data(using: .utf8)
+        let sig = try CryptoManager.signRSA(b64)
+        let body = "content=\(b64)&recipient=\(recipient)&signature=\(sig)"
+        request.httpBody = body.data(using: .utf8)
         _ = try await session.data(for: request)
     }
 

--- a/ios/PrivateLine/CryptoManager.swift
+++ b/ios/PrivateLine/CryptoManager.swift
@@ -170,6 +170,21 @@ enum CryptoManager {
         return String(decoding: decrypted, as: UTF8.self)
     }
 
+    /// Sign base64-encoded ciphertext using the cached private key.
+    static func signRSA(_ b64: String) throws -> String {
+        guard let key = rsaPrivateKey, let data = Data(base64Encoded: b64) else {
+            throw CocoaError(.coderValueNotFound)
+        }
+        var error: Unmanaged<CFError>?
+        guard let sig = SecKeyCreateSignature(key,
+                                              .rsaSignatureMessagePKCS1v15SHA256,
+                                              data as CFData,
+                                              &error) as Data? else {
+            throw error!.takeRetainedValue() as Error
+        }
+        return sig.base64EncodedString()
+    }
+
     /// Compute SHA256 fingerprint of a PEM-encoded public key
     static func fingerprint(of pem: String) -> String {
         let b64 = pem


### PR DESCRIPTION
## Summary
- add `signature` column to `Message`
- sign messages in Chat.js and CryptoManager.swift
- verify signatures on the server before storing and returning
- update unit tests for new signing behavior

## Testing
- `pytest -q`
- `CI=true npm test --silent -- --watchAll=false`