### PR TITLE
Fix CI test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
       - run: pip install -r backend/requirements.txt
       - run: pytest
 
@@ -20,6 +26,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15'
       - name: Run iOS tests
         run: xcodebuild -scheme PrivateLine-Package -destination 'platform=iOS Simulator,name=iPhone 14' test
         working-directory: ios


### PR DESCRIPTION
## Summary
- update backend job to install Rust before installing dependencies
- set up Xcode 15 in iOS job so Swift 5.9 builds work

## Testing
- `pytest -q`
- `xcodebuild -version` *(fails: command not found)*