### PR TITLE
Implement message signing and verification

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -73,6 +73,7 @@ class Message(db.Model):
     recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     group_id = db.Column(db.Integer, db.ForeignKey('group.id'))
     file_id = db.Column(db.Integer, db.ForeignKey('file.id'))
+    signature = db.Column(db.String(684), nullable=False)
 
 
 class PinnedKey(db.Model):

--- a/frontend/src/components/__tests__/Chat.test.js
+++ b/frontend/src/components/__tests__/Chat.test.js
@@ -30,10 +30,14 @@ afterEach(() => {
 it('fetches existing messages and shows websocket updates', async () => {
   const socket = { on: jest.fn(), disconnect: jest.fn() };
   io.mockReturnValue(socket);
-  api.get.mockResolvedValue({ status: 200, data: { messages: [{ id: 1, content: 'hello' }] } });
+  api.get.mockResolvedValueOnce({ status: 200, data: { groups: [] } });
+  api.get.mockResolvedValueOnce({ status: 200, data: { messages: [{ id: 1, content: 'hello' }] } });
 
   render(<Chat />);
 
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/api/groups');
+  });
   await waitFor(() => {
     expect(api.get).toHaveBeenCalledWith('/api/messages');
   });
@@ -56,10 +60,14 @@ it('fetches existing messages and shows websocket updates', async () => {
 it('uses selected recipient when sending a message', async () => {
   const socket = { on: jest.fn(), disconnect: jest.fn() };
   io.mockReturnValue(socket);
+  api.get.mockResolvedValueOnce({ status: 200, data: { groups: [] } });
   api.get.mockResolvedValueOnce({ status: 200, data: { messages: [] } });
 
   render(<Chat />);
 
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/api/groups');
+  });
   await waitFor(() => {
     expect(api.get).toHaveBeenCalledWith('/api/messages');
   });

--- a/ios/PrivateLine/APIService.swift
+++ b/ios/PrivateLine/APIService.swift
@@ -167,7 +167,8 @@ class APIService: ObservableObject {
         var request = URLRequest(url: baseURL.appendingPathComponent("groups/\(groupId)/messages"))
         request.httpMethod = "POST"
         request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.httpBody = "content=\(content)&group_id=\(groupId)".data(using: .utf8)
+        let sig = try CryptoManager.signMessage(content).base64EncodedString()
+        request.httpBody = "content=\(content)&group_id=\(groupId)&signature=\(sig)".data(using: .utf8)
         _ = try await session.data(for: request)
     }
 
@@ -223,7 +224,8 @@ class APIService: ObservableObject {
         }
         let encrypted = try CryptoManager.encryptRSA(content, publicKeyPem: publicKeyPem)
         let b64 = encrypted.base64EncodedString()
-        request.httpBody = "content=\(b64)".data(using: .utf8)
+        let sig = try CryptoManager.signMessage(b64).base64EncodedString()
+        request.httpBody = "content=\(b64)&signature=\(sig)".data(using: .utf8)
         _ = try await session.data(for: request)
     }
 

--- a/ios/PrivateLine/CryptoManager.swift
+++ b/ios/PrivateLine/CryptoManager.swift
@@ -170,6 +170,17 @@ enum CryptoManager {
         return String(decoding: decrypted, as: UTF8.self)
     }
 
+    /// Sign ``message`` using the cached private key with RSA-PSS.
+    static func signMessage(_ message: String) throws -> Data {
+        guard let key = rsaPrivateKey else { throw CocoaError(.coderValueNotFound) }
+        let data = message.data(using: .utf8)!
+        var error: Unmanaged<CFError>?
+        guard let sig = SecKeyCreateSignature(key, .rsaSignatureMessagePSSSHA256, data as CFData, &error) as Data? else {
+            throw error!.takeRetainedValue() as Error
+        }
+        return sig
+    }
+
     /// Compute SHA256 fingerprint of a PEM-encoded public key
     static func fingerprint(of pem: String) -> String {
         let b64 = pem


### PR DESCRIPTION
## Summary
- add signature column to `Message`
- enforce signing in API and clients
- verify signatures before storing or returning
- update tests for new behavior

## Testing
- `npm test --silent --prefix frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410375568483218b92ad497d81ef09