### PR TITLE
Add per-group encryption key endpoints and client support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -80,6 +80,7 @@ from .resources import (
     Messages,
     PublicKey,
     Groups,
+    GroupKey,
     GroupMessages,
     FileUpload,
     FileDownload,
@@ -114,6 +115,7 @@ api.add_resource(Login, '/api/login')
 api.add_resource(Messages, '/api/messages')
 api.add_resource(PublicKey, '/api/public_key/<string:username>')
 api.add_resource(Groups, '/api/groups')
+api.add_resource(GroupKey, '/api/groups/<int:group_id>/key')
 api.add_resource(GroupMessages, '/api/groups/<int:group_id>/messages')
 api.add_resource(FileUpload, '/api/files')
 api.add_resource(FileDownload, '/api/files/<int:file_id>')

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,6 +5,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption, PublicFormat
 from cryptography.hazmat.backends import default_backend
+from base64 import b64encode
+import os
 
 """
 When a new user is registered, a public-private key pair is generated.
@@ -44,6 +46,11 @@ class User(db.Model):
 class Group(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(64), unique=True, nullable=False)
+    aes_key = db.Column(
+        db.String(44),
+        nullable=False,
+        default=lambda: b64encode(os.urandom(32)).decode(),
+    )
 
 
 class GroupMember(db.Model):

--- a/ios/PrivateLine/WebSocketService.swift
+++ b/ios/PrivateLine/WebSocketService.swift
@@ -31,8 +31,8 @@ class WebSocketService: ObservableObject {
                    let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let b64 = payload["content"] as? String {
                     var plaintext: String?
-                    if let _ = payload["group_id"], let ct = Data(base64Encoded: b64) {
-                        plaintext = try? CryptoManager.decryptGroupMessage(ct)
+                    if let gid = payload["group_id"] as? Int, let ct = Data(base64Encoded: b64) {
+                        plaintext = try? CryptoManager.decryptGroupMessage(ct, groupId: gid)
                     } else {
                         plaintext = try? CryptoManager.decryptRSA(b64)
                     }

--- a/ios/PrivateLineTests/CryptoManagerTests.swift
+++ b/ios/PrivateLineTests/CryptoManagerTests.swift
@@ -8,4 +8,12 @@ final class CryptoManagerTests: XCTestCase {
         let decrypted = try CryptoManager.decryptMessage(encrypted)
         XCTAssertEqual(decrypted, message)
     }
+
+    func testGroupEncryptionRoundtrip() throws {
+        let key = Data(repeating: 1, count: 32).base64EncodedString()
+        CryptoManager.storeGroupKey(key, groupId: 1)
+        let encrypted = try CryptoManager.encryptGroupMessage("hi", groupId: 1)
+        let decrypted = try CryptoManager.decryptGroupMessage(encrypted, groupId: 1)
+        XCTAssertEqual(decrypted, "hi")
+    }
 }


### PR DESCRIPTION
## Summary
- store a unique AES key with each `Group`
- expose `/api/groups/<id>/key` GET and PUT endpoints
- cache group keys in the React chat client
- update iOS CryptoManager and APIService to handle per-group keys
- test group key distribution

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`