### PR TITLE
Add example environment file and TLS guidance

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,21 @@
+# Example environment configuration for PrivateLine
+# Copy this file to .env and provide real values before running the app.
+JWT_SECRET_KEY=development-secret
+# Base64-encoded 32 byte key for encrypting stored messages
+# AES_KEY=$(openssl rand -base64 32)
+AES_KEY=tO2Oi75HoPMTN8YSpzLEMRUSPIKwktb6/jQ3AkGXuOA=
+DATABASE_URI=sqlite:///private_line.db
+#FERNET_KEY=optional-random-key
+
+# URL for the backend API used by the React frontend
+REACT_APP_API_URL=http://localhost:5000
+SOCKETIO_ORIGINS=http://localhost:3000
+
+# APNs certificate and topic for iOS push notifications
+APNS_CERT=apns.pem
+APNS_TOPIC=com.example.PrivateLine
+
+# VAPID keys for Web Push
+VAPID_PRIVATE_KEY=vapid_private_key
+VAPID_SUBJECT=mailto:admin@example.com
+#REACT_APP_VAPID_PUBLIC_KEY=

--- a/README.md
+++ b/README.md
@@ -152,3 +152,10 @@ Copy the contents of `frontend/build` to the directory served by your HTTP serve
 `JWT_SECRET_KEY`, `AES_KEY` and `DATABASE_URI` are configured on the backend in
 production.
 
+
+### TLS Termination
+For HTTPS deployments, place a reverse proxy such as Nginx in front of the application.
+Terminate TLS at the proxy and forward traffic to Gunicorn on port 5000.
+If running with Docker, you can use an nginx-proxy setup with the LetsEncrypt companion
+container for automatic certificate management.
+


### PR DESCRIPTION
## Summary
- add a `.env` file populated with example configuration values
- document TLS termination with a reverse proxy

## Testing
- `pytest -q`
- `npm test --silent`