### PR TITLE
Add production Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ JWT_SECRET_KEY=your-secret-key
 # AES_KEY=$(openssl rand -base64 32)
 #AES_KEY=
 #DATABASE_URI=sqlite:///secure_messaging.db
+#POSTGRES_PASSWORD=change-me
+#REDIS_URL=redis://redis:6379/0
+#SENTRY_DSN=
 #FERNET_KEY=optional-random-key
 
 # URL for the backend API used by the React frontend

--- a/README.md
+++ b/README.md
@@ -159,3 +159,21 @@ Terminate TLS at the proxy and forward traffic to Gunicorn on port 5000.
 If running with Docker, you can use an nginx-proxy setup with the LetsEncrypt companion
 container for automatic certificate management.
 
+### Example production setup on DigitalOcean
+
+One approach for hosting is a small **DigitalOcean Droplet** running Docker
+and Docker Compose. After provisioning an Ubuntu droplet and installing the
+Docker tooling, copy `.env.example` to `.env` and set at least
+`POSTGRES_PASSWORD`, `JWT_SECRET_KEY` and `AES_KEY`. Optionally provide
+`SENTRY_DSN` for error reporting.
+
+Deploy the stack using the production compose file:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Logs from the services are sent to the address defined in the `gelf` logging
+driver. Adjust `logcollector` in `docker-compose.prod.yml` to point at your
+aggregator (e.g. Graylog or Logstash).
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,10 +16,21 @@ from flask_jwt_extended import (
 )
 from flask_socketio import SocketIO, disconnect, join_room
 from dotenv import load_dotenv
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 # Load environment variables from a .env file if present.  This keeps
 # secret values such as JWT_SECRET_KEY out of source control.
 load_dotenv()
+
+# Initialize Sentry for error monitoring when a DSN is provided
+sentry_dsn = os.environ.get("SENTRY_DSN")
+if sentry_dsn:
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        integrations=[FlaskIntegration()],
+        traces_sample_rate=1.0,
+    )
 
 # Initialize Flask app and extensions
 app = Flask(__name__)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,5 @@ cryptography==36.0.1
 Werkzeug==2.1.1
 itsdangerous==2.1.1
 SQLAlchemy==1.4.48
+sentry-sdk==1.39.2
+blinker==1.7.0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file: .env
+    command: gunicorn -k gevent -w 1 backend.app:app
+    depends_on:
+      - db
+      - redis
+    environment:
+      DATABASE_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - "5000:5000"
+    logging:
+      driver: "gelf"
+      options:
+        gelf-address: "udp://logcollector:12201"
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+      args:
+        REACT_APP_API_URL: ${REACT_APP_API_URL}
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"
+    logging:
+      driver: "gelf"
+      options:
+        gelf-address: "udp://logcollector:12201"
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    logging:
+      driver: "gelf"
+      options:
+        gelf-address: "udp://logcollector:12201"
+  redis:
+    image: redis:7
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+    logging:
+      driver: "gelf"
+      options:
+        gelf-address: "udp://logcollector:12201"
+volumes:
+  db-data:
+  redis-data:


### PR DESCRIPTION
## Summary
- add production docker-compose file with Postgres and Redis
- store DB & Redis data in volumes
- initialize Sentry in backend
- document DigitalOcean production deployment
- expose new env vars in `.env.example`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm install`
- `npm test --silent`