### PR TITLE
Add message deletion and read receipts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -100,6 +100,8 @@ from .resources import (
     RefreshToken,
     RevokeToken,
     PushTokenResource,
+    MessageResource,
+    MessageRead,
 )
 
 # Reject WebSocket connections that do not provide a valid JWT.
@@ -135,6 +137,8 @@ api.add_resource(AccountSettings, '/api/account-settings')
 api.add_resource(RefreshToken, '/api/refresh')
 api.add_resource(RevokeToken, '/api/revoke')
 api.add_resource(PushTokenResource, '/api/push-token')
+api.add_resource(MessageResource, '/api/messages/<int:message_id>')
+api.add_resource(MessageRead, '/api/messages/<int:message_id>/read')
 
 # Run the development server only when executed directly.
 if __name__ == '__main__':

--- a/backend/models.py
+++ b/backend/models.py
@@ -81,6 +81,7 @@ class Message(db.Model):
     group_id = db.Column(db.Integer, db.ForeignKey('group.id'))
     file_id = db.Column(db.Integer, db.ForeignKey('file.id'))
     signature = db.Column(db.String(684), nullable=False)
+    read = db.Column(db.Boolean, default=False, nullable=False)
 
 
 class PinnedKey(db.Model):

--- a/frontend/src/components/Chat.css
+++ b/frontend/src/components/Chat.css
@@ -53,6 +53,20 @@
   border-radius: 0.5rem;
 }
 
+.read-receipt {
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.conversation-list {
+  background: #fafafa;
+  height: 100%;
+}
+
+.conversation-item.active {
+  background: #e0e0e0;
+}
+
 body[data-theme='dark'] {
   --chat-bg: #2a2c2e;
 }

--- a/ios/PrivateLine/ChatView.swift
+++ b/ios/PrivateLine/ChatView.swift
@@ -28,6 +28,11 @@ struct ChatView: View {
             List(viewModel.messages) { msg in
                 HStack {
                     Text(msg.content)
+                    if let read = msg.read, msg.id != 0 {
+                        Spacer()
+                        Image(systemName: read ? "checkmark.circle.fill" : "checkmark.circle")
+                            .foregroundColor(.gray)
+                    }
                     if let fid = msg.file_id {
                         Link("attachment", destination: URL(string: "\(viewModel.api.baseURLString)/files/\(fid)")!)
                     }

--- a/ios/PrivateLine/ChatViewModel.swift
+++ b/ios/PrivateLine/ChatViewModel.swift
@@ -25,6 +25,9 @@ final class ChatViewModel: ObservableObject {
             groups = try await api.fetchGroups()
             let fetched = try await (selectedGroup != nil ? api.fetchGroupMessages(selectedGroup!) : api.fetchMessages())
             messages = fetched
+            for msg in fetched where msg.read != true && (msg.id != 0) {
+                try? await api.markMessageRead(id: msg.id)
+            }
             MessageStore.save(fetched)
             if let token = api.authToken {
                 socket.connect(token: token)
@@ -50,7 +53,7 @@ final class ChatViewModel: ObservableObject {
             } else {
                 try await api.sendMessage(input, to: recipient)
             }
-            let msg = Message(id: Int(Date().timeIntervalSince1970), content: input, file_id: fileId)
+            let msg = Message(id: Int(Date().timeIntervalSince1970), content: input, file_id: fileId, read: true)
             messages.append(msg)
             MessageStore.save(messages)
             input = ""

--- a/ios/PrivateLine/Message.swift
+++ b/ios/PrivateLine/Message.swift
@@ -7,6 +7,7 @@ struct Message: Identifiable, Decodable {
     /// Decrypted text content.
     let content: String
     let file_id: Int?
+    let read: Bool?
 }
 
 struct Group: Identifiable, Decodable {


### PR DESCRIPTION
## Summary
- refine chat UI with read receipts, conversation styling, and delete buttons
- track read status in messages
- allow deleting messages and marking them as read via API
- sync iOS app with read receipt and deletion APIs
- test message deletion and read receipt workflow

## Testing
- `npm test --silent`
- `pytest -q`