### PR TITLE
Improve account settings feedback

### DIFF
--- a/frontend/src/components/AccountSettings.js
+++ b/frontend/src/components/AccountSettings.js
@@ -1,6 +1,6 @@
 // A part of the user account management interface, focusing on updating account information.
 import React, { useState } from 'react';
-import { Box, Button, TextField, Typography } from '@mui/material';
+import { Box, Button, TextField, Typography, Snackbar, Alert } from '@mui/material';
 import api from '../api';
 
 /*
@@ -14,9 +14,12 @@ function AccountSettings() {
   const [email, setEmail] = useState('');
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
+  const [error, setError] = useState('');
+  const [openSuccess, setOpenSuccess] = useState(false);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
+    setError('');
 
     try {
       const response = await api.put('/api/account-settings', {
@@ -26,14 +29,19 @@ function AccountSettings() {
       });
 
       if (response.status === 200) {
-        // Handle successful account update, e.g., show a success message
-
-        // Redirect to another appropriate page or update the interface
+        setOpenSuccess(true);
+        setEmail('');
+        setCurrentPassword('');
+        setNewPassword('');
       } else {
-        // Handle account update errors
+        setError(response.data.message || 'Account update failed');
       }
     } catch (error) {
-      // Handle network or server errors
+      if (error.response && error.response.data && error.response.data.message) {
+        setError(error.response.data.message);
+      } else {
+        setError('An error occurred while updating the account');
+      }
     }
   };
 
@@ -67,9 +75,27 @@ function AccountSettings() {
         onChange={(e) => setNewPassword(e.target.value)}
         margin="normal"
       />
+      {error && (
+        <Typography color="error" sx={{ mt: 1 }}>
+          {error}
+        </Typography>
+      )}
       <Button type="submit" variant="contained" sx={{ mt: 2 }}>
         Update
       </Button>
+      <Snackbar
+        open={openSuccess}
+        autoHideDuration={6000}
+        onClose={() => setOpenSuccess(false)}
+      >
+        <Alert
+          onClose={() => setOpenSuccess(false)}
+          severity="success"
+          sx={{ width: '100%' }}
+        >
+          Account updated successfully!
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add success and error handling for account update requests
- show Snackbar confirmation on success

## Testing
- `npm test --prefix frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68432eb4a7c88321b4b7d72cf8147ec8