### PR TITLE
Add logout handler

### DIFF
--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
+import api from '../api';
 import {
   AppBar,
   Toolbar,
@@ -11,6 +12,21 @@ import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 
 function NavigationBar({ onToggleTheme, currentTheme }) {
+  const history = useHistory();
+
+  const handleLogout = async () => {
+    try {
+      await api.post('/api/revoke');
+    } catch (e) {
+      console.error('Failed to revoke token', e);
+    } finally {
+      localStorage.removeItem('access_token');
+      localStorage.removeItem('pinned_keys');
+      sessionStorage.removeItem('private_key_pem');
+      history.push('/login');
+    }
+  };
+
   return (
     <AppBar position="static">
       <Toolbar>
@@ -28,6 +44,9 @@ function NavigationBar({ onToggleTheme, currentTheme }) {
         </Button>
         <Button color="inherit" component={Link} to="/account">
           Account
+        </Button>
+        <Button color="inherit" onClick={handleLogout}>
+          Logout
         </Button>
         <IconButton color="inherit" onClick={onToggleTheme} sx={{ ml: 1 }}>
           {currentTheme === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}

--- a/frontend/src/components/__tests__/NavigationBar.test.js
+++ b/frontend/src/components/__tests__/NavigationBar.test.js
@@ -1,0 +1,33 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import NavigationBar from '../NavigationBar';
+import api from '../../api';
+
+jest.mock('../../api');
+
+afterEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+test('logout revokes token and redirects to login', async () => {
+  api.post.mockResolvedValueOnce({ status: 200 });
+  const history = createMemoryHistory({ initialEntries: ['/chat'] });
+  localStorage.setItem('access_token', 'abc');
+  localStorage.setItem('pinned_keys', '[]');
+  sessionStorage.setItem('private_key_pem', 'pk');
+
+  const { getByRole } = render(
+    <Router history={history}>
+      <NavigationBar onToggleTheme={() => {}} currentTheme="light" />
+    </Router>
+  );
+
+  fireEvent.click(getByRole('button', { name: /logout/i }));
+
+  await waitFor(() => expect(api.post).toHaveBeenCalledWith('/api/revoke'));
+  await waitFor(() => expect(localStorage.getItem('access_token')).toBeNull());
+  await waitFor(() => expect(history.location.pathname).toBe('/login'));
+});


### PR DESCRIPTION
## Summary
- add `/api/revoke` based logout in `NavigationBar`
- remove cached credentials on logout
- test logout workflow

## Testing
- `npm test --silent`
- `pytest -q`