### PR TITLE
Add users endpoint and fetch user list

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -90,6 +90,7 @@ from .resources import (
     Login,
     Messages,
     PublicKey,
+    Users,
     Groups,
     GroupKey,
     GroupMessages,
@@ -127,6 +128,7 @@ api.add_resource(Register, '/api/register')
 api.add_resource(Login, '/api/login')
 api.add_resource(Messages, '/api/messages')
 api.add_resource(PublicKey, '/api/public_key/<string:username>')
+api.add_resource(Users, '/api/users')
 api.add_resource(Groups, '/api/groups')
 api.add_resource(GroupKey, '/api/groups/<int:group_id>/key')
 api.add_resource(GroupMessages, '/api/groups/<int:group_id>/messages')

--- a/backend/resources.py
+++ b/backend/resources.py
@@ -220,6 +220,19 @@ class PublicKey(Resource):
         return {"public_key": user.public_key_pem}
 
 
+class Users(Resource):
+    """Return a list of usernames, optionally filtered by a search query."""
+
+    @jwt_required()
+    def get(self):
+        q = request.args.get("q")
+        query = User.query
+        if q:
+            query = query.filter(User.username.contains(q))
+        users = [u.username for u in query.all()]
+        return {"users": users}
+
+
 class Groups(Resource):
     """Create or list chat groups."""
 

--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -19,8 +19,6 @@ import { arrayBufferToBase64, base64ToArrayBuffer } from '../utils/encoding';
 import { loadKeyMaterial } from '../utils/secureStore';
 import { setupWebPush } from '../utils/push';
 
-const USERS = ['alice', 'bob', 'carol'];
-
 // Chat groups loaded from the backend
 // Each has {id, name}
 
@@ -220,8 +218,9 @@ function Chat() {
   const [socket, setSocket] = useState(null);
   const [privateKey, setPrivateKey] = useState(null);
   const [signKey, setSignKey] = useState(null);
-  const [recipient, setRecipient] = useState('alice');
+  const [recipient, setRecipient] = useState('');
   const [groups, setGroups] = useState([]);
+  const [users, setUsers] = useState([]);
   const [selectedGroup, setSelectedGroup] = useState(null);
   const [file, setFile] = useState(null);
 
@@ -320,6 +319,20 @@ function Chat() {
         if (s) s.disconnect();
       };
     }, [selectedGroup, recipient]);
+
+    useEffect(() => {
+      async function fetchUsers() {
+        try {
+          const resp = await api.get('/api/users');
+          if (resp.status === 200 && Array.isArray(resp.data.users)) {
+            setUsers(resp.data.users);
+          }
+        } catch (e) {
+          console.error('Failed to fetch users', e);
+        }
+      }
+      fetchUsers();
+    }, []);
 
     const deleteMessage = async (id) => {
       try {
@@ -420,7 +433,7 @@ function Chat() {
             <ListItem>
               <ListItemText primary="Conversations" />
             </ListItem>
-            {USERS.map((user) => (
+            {users.map((user) => (
               <ListItem
                 button
                 className={`conversation-item${!selectedGroup && recipient === user ? ' active' : ''}`}

--- a/frontend/src/components/__tests__/Chat.test.js
+++ b/frontend/src/components/__tests__/Chat.test.js
@@ -33,6 +33,7 @@ it('fetches existing messages and shows websocket updates', async () => {
   io.mockReturnValue(socket);
   api.get.mockResolvedValueOnce({ status: 200, data: { groups: [] } });
   api.get.mockResolvedValueOnce({ status: 200, data: { messages: [{ id: 1, content: 'hello' }] } });
+  api.get.mockResolvedValueOnce({ status: 200, data: { users: ['alice', 'bob'] } });
 
   render(<Chat />);
 
@@ -41,6 +42,9 @@ it('fetches existing messages and shows websocket updates', async () => {
   });
   await waitFor(() => {
     expect(api.get).toHaveBeenCalledWith('/api/messages');
+  });
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/api/users');
   });
 
   // existing message from API should appear
@@ -63,6 +67,7 @@ it('uses selected recipient when sending a message', async () => {
   io.mockReturnValue(socket);
   api.get.mockResolvedValueOnce({ status: 200, data: { groups: [] } });
   api.get.mockResolvedValueOnce({ status: 200, data: { messages: [] } });
+  api.get.mockResolvedValueOnce({ status: 200, data: { users: ['alice', 'bob'] } });
 
   render(<Chat />);
 
@@ -71,6 +76,9 @@ it('uses selected recipient when sending a message', async () => {
   });
   await waitFor(() => {
     expect(api.get).toHaveBeenCalledWith('/api/messages');
+  });
+  await waitFor(() => {
+    expect(api.get).toHaveBeenCalledWith('/api/users');
   });
 
   const bobItem = screen.getByText('bob');

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -458,3 +458,19 @@ def test_message_delete_and_read(client):
 
     resp = client.get('/api/messages', headers=headers)
     assert resp.get_json()['messages'] == []
+
+
+def test_users_endpoint(client):
+    register_user(client, 'alice')
+    register_user(client, 'bob')
+    token = login_user(client, 'alice').get_json()['access_token']
+    headers = {'Authorization': f'Bearer {token}'}
+
+    resp = client.get('/api/users', headers=headers)
+    assert resp.status_code == 200
+    names = resp.get_json()['users']
+    assert 'alice' in names and 'bob' in names
+
+    resp = client.get('/api/users?q=bo', headers=headers)
+    assert resp.status_code == 200
+    assert resp.get_json()['users'] == ['bob']


### PR DESCRIPTION
## Summary
- expose `/api/users` to retrieve or search for usernames
- fetch user list in Chat component on mount
- update tests for new endpoint
- add coverage for `/api/users` API

## Testing
- `pytest -q`