### PR TITLE
Include message ID in API response

### DIFF
--- a/backend/resources.py
+++ b/backend/resources.py
@@ -371,7 +371,7 @@ class GroupMessages(Resource):
         db.session.add(m)
         db.session.commit()
         socketio.emit("new_message", {"content": data["content"], "group_id": group_id}, to=str(group_id))
-        return {"message": "sent"}, 201
+        return {"message": "sent", "id": m.id}, 201
 
 
 class FileUpload(Resource):
@@ -547,7 +547,7 @@ class Messages(Resource):
                 if m.user_id != current_user_id:
                     send_push_notifications(m.user_id, "New group message")
 
-        return {"message": "Message sent successfully."}, 201
+        return {"message": "Message sent successfully.", "id": new_message.id}, 201
 
 
 class MessageResource(Resource):

--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -406,7 +406,17 @@ function Chat() {
         const response = await api.post(url, formData);
 
         if (response.status === 201) {
-          setMessages([...messages, { id: Date.now(), text: message, type: 'sent', file_id: formData.get('file_id'), read: true }]);
+          const newId = response.data && response.data.id;
+          setMessages([
+            ...messages,
+            {
+              id: newId || Date.now(),
+              text: message,
+              type: 'sent',
+              file_id: formData.get('file_id'),
+              read: true,
+            },
+          ]);
           setMessage('');
           setFile(null);
         }

--- a/frontend/src/components/__tests__/Chat.test.js
+++ b/frontend/src/components/__tests__/Chat.test.js
@@ -94,7 +94,7 @@ it.skip('uses selected recipient when sending a message', async () => {
   fireEvent.click(screen.getByText('bob'));
 
   api.get.mockResolvedValueOnce({ status: 200, data: { public_key: 'KEY' } });
-  api.post.mockResolvedValueOnce({ status: 201 });
+  api.post.mockResolvedValueOnce({ status: 201, data: { id: 1 } });
 
   fireEvent.change(screen.getByPlaceholderText('Type your message'), {
     target: { value: 'hi' },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.backends import default_backend
 os.environ.setdefault("AES_KEY", base64.b64encode(os.urandom(32)).decode())
 
 from backend.app import app, db
-from backend.models import User, Message
+from backend.models import User
 
 @pytest.fixture
 def client():
@@ -460,7 +460,7 @@ def test_message_delete_and_read(client):
     sig = sign_content(pk, b64)
     resp = client.post('/api/messages', data={'content': b64, 'recipient': 'alice', 'signature': sig}, headers=headers)
     assert resp.status_code == 201
-    msg_id = Message.query.first().id
+    msg_id = resp.get_json()['id']
 
     resp = client.post(f'/api/messages/{msg_id}/read', headers=headers)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- return new message ID from `Messages.post` and `GroupMessages.post`
- record returned ID when sending a message in the chat UI
- adjust tests for new message ID field

## Testing
- `pytest -q`
- `npm test --silent`