### PR TITLE
Support file attachments in API calls

### DIFF
--- a/ios/PrivateLine/ChatViewModel.swift
+++ b/ios/PrivateLine/ChatViewModel.swift
@@ -53,9 +53,9 @@ final class ChatViewModel: ObservableObject {
                 attachment = nil
             }
             if let gid = selectedGroup {
-                try await api.sendGroupMessage(input, groupId: gid)
+                try await api.sendGroupMessage(input, groupId: gid, fileId: fileId)
             } else {
-                try await api.sendMessage(input, to: recipient)
+                try await api.sendMessage(input, to: recipient, fileId: fileId)
             }
             let msg = Message(id: Int(Date().timeIntervalSince1970), content: input, file_id: fileId, read: true)
             messages.append(msg)


### PR DESCRIPTION
## Summary
- allow optional file IDs when sending messages
- pass recipient field through REST API calls
- update ChatViewModel to send file IDs to API if present

## Testing
- `swift test -q` *(fails: Info.plist is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845aac79b38832181a4d2d4f5450102