### PR TITLE
Improve iOS setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,17 @@ npm test
 The tests exercise the Flask API endpoints as well as the React components.
 
 ## iOS Client
-A minimal SwiftUI client is located in the `ios/` directory. Open it with Xcode and run the app while the backend is running locally.
+A minimal SwiftUI client is located in the `ios/` directory. See
+[ios/README.md](ios/README.md) for detailed setup instructions.
+
+- Update `Info.plist` so the `BackendBaseURL` and `WebSocketURL` keys point at
+  your server if it does not run on `localhost`.
+- Run the Swift package tests with
+  `xcodebuild -scheme PrivateLine-Package test` or choose **Product → Test** in
+  Xcode.
+- To receive push notifications, start the backend with `APNS_CERT` and
+  `APNS_TOPIC`. The app's `NotificationManager` will register its APNs token by
+  calling `/api/push-token` after a user signs in.
 
 ## Push Notifications
 The backend can notify offline clients via Apple Push Notification service (APNs)

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,11 +1,14 @@
 # iOS Client (SwiftUI)
 
 This directory contains a lightweight SwiftUI client for the PrivateLine backend. It now persists credentials in the Keychain with Face ID/Touch ID protection, caches messages for offline viewing and encrypts outgoing messages locally using CryptoKit.
+See the [project README](../README.md) for backend configuration and environment
+variables.
 
 ## Getting Started
 
 1. Open the `ios` folder in Xcode.
-2. Modify `Info.plist` if your backend does not run on `localhost`. The keys `BackendBaseURL` and `WebSocketURL` control the REST and WebSocket endpoints.
+2. Open `Info.plist` and change the string values of `BackendBaseURL` and
+   `WebSocketURL` if your backend does not run on `localhost`.
 3. Build and run the app in the iOS simulator.
 
 After launching the app you will be greeted with a short onboarding flow describing encryption and privacy. You can then create an account or log in. Messages are loaded from local storage first and updated in real time via WebSockets.


### PR DESCRIPTION
## Summary
- document how to set BackendBaseURL and WebSocketURL
- describe running Swift tests and NotificationManager token registration
- add references between the root README and ios/README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*
- `npm test` *(fails: react-scripts not found)*