### PR TITLE
Include server IDs in WebSocket messages

### DIFF
--- a/backend/resources.py
+++ b/backend/resources.py
@@ -383,7 +383,11 @@ class GroupMessages(Resource):
         )
         db.session.add(m)
         db.session.commit()
-        socketio.emit("new_message", {"content": data["content"], "group_id": group_id}, to=str(group_id))
+        socketio.emit(
+            "new_message",
+            {"id": m.id, "content": data["content"], "group_id": group_id},
+            to=str(group_id),
+        )
         return {"message": "sent", "id": m.id}, 201
 
 
@@ -560,6 +564,7 @@ class Messages(Resource):
             socketio.emit(
                 "new_message",
                 {
+                    "id": new_message.id,
                     "content": data["content"],
                     "sender_id": current_user_id,
                     "recipient_id": recipient.id,
@@ -573,6 +578,7 @@ class Messages(Resource):
             socketio.emit(
                 "new_message",
                 {
+                    "id": new_message.id,
                     "content": data["content"],
                     "sender_id": current_user_id,
                     "group_id": gid,

--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -353,7 +353,13 @@ function Chat() {
           ) {
             setMessages((prev) => [
               ...prev,
-              { id: Date.now(), text, type: 'received', file_id: payload.file_id, read: true },
+              {
+                id: payload.id || Date.now(),
+                text,
+                type: 'received',
+                file_id: payload.file_id,
+                read: true,
+              },
             ]);
           }
         });
@@ -466,7 +472,7 @@ function Chat() {
           setMessages([
             ...messages,
             {
-              id: newId || Date.now(),
+              id: newId,
               text: message,
               type: 'sent',
               file_id: formData.get('file_id'),

--- a/ios/PrivateLine/WebSocketService.swift
+++ b/ios/PrivateLine/WebSocketService.swift
@@ -50,7 +50,8 @@ class WebSocketService: ObservableObject {
                     }
                     if let plaintext = plaintext {
                         let fid = payload["file_id"] as? Int
-                        let msg = Message(id: Int(Date().timeIntervalSince1970), content: plaintext, file_id: fid)
+                        let msgId = payload["id"] as? Int ?? Int(Date().timeIntervalSince1970)
+                        let msg = Message(id: msgId, content: plaintext, file_id: fid, read: true)
                         DispatchQueue.main.async {
                             self?.messages.append(msg)
                         }


### PR DESCRIPTION
## Summary
- attach the DB id to each `new_message` emit
- use the id from the payload in the React chat UI
- use the id from the payload in the iOS WebSocket handler
- test that group message ids work for read receipts and deletion

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`