### PR TITLE
Add user ID decode helper and use in WebSocket check

### DIFF
--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -18,6 +18,7 @@ import './Chat.css';
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../utils/encoding';
 import { loadKeyMaterial } from '../utils/secureStore';
 import { setupWebPush } from '../utils/push';
+import { getUserIdFromToken } from '../utils/auth';
 
 // Chat groups loaded from the backend. Each entry contains
 // an ``id`` and ``name`` used to populate the sidebar.
@@ -256,6 +257,7 @@ function Chat() {
   const [messages, setMessages] = useState([]);
   const [privateKey, setPrivateKey] = useState(null);
   const [signKey, setSignKey] = useState(null);
+  const [userId, setUserId] = useState(null);
   const [recipient, setRecipient] = useState('');
   const [groups, setGroups] = useState([]);
   const [users, setUsers] = useState([]);
@@ -271,6 +273,7 @@ function Chat() {
 
       async function init() {
         setupWebPush();
+        setUserId(getUserIdFromToken());
         let key = null;
         const pem = sessionStorage.getItem('private_key_pem');
         if (pem) {
@@ -349,7 +352,9 @@ function Chat() {
           }
           if (
             (payload.group_id && payload.group_id === selectedGroup) ||
-            (!payload.group_id && !selectedGroup && payload.recipient_id === recipient)
+            (!payload.group_id &&
+              !selectedGroup &&
+              (payload.sender_id === userId || payload.recipient_id === userId))
           ) {
             setMessages((prev) => [
               ...prev,

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,0 +1,11 @@
+export function getUserIdFromToken() {
+  const token = localStorage.getItem('access_token');
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.sub ? parseInt(payload.sub, 10) : null;
+  } catch (e) {
+    console.error('Failed to decode token', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- decode JWTs from localStorage to read the current user ID
- store the decoded ID in Chat component state
- use that ID when filtering new WebSocket messages

## Testing
- `npm test --prefix frontend --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487e0e736883218c0036d41edfdec8