### PR TITLE
Clean up unused FERNET_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ JWT_SECRET_KEY=your-secret-key
 #POSTGRES_PASSWORD=change-me
 #REDIS_URL=redis://redis:6379/0  # rate limiting and token blocklist
 #SENTRY_DSN=
-#FERNET_KEY=optional-random-key
 #SOCKETIO_ORIGINS=http://localhost:3000
 
 # URL for the backend API used by the React frontend


### PR DESCRIPTION
## Summary
- remove unused `FERNET_KEY` line from `.env.example`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7028f248321864f210bf5c6b175