### PR TITLE
Require JWT_SECRET_KEY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The backend also includes rate limiting on message sending, JWT-based user authe
 To run the application, follow these steps:
 1. Clone the repository.
 2. Copy `.env.example` to `.env` and provide values for the following variables:
-   * `JWT_SECRET_KEY` – key used for JWT signatures.
+   * `JWT_SECRET_KEY` – **required** key used for JWT signatures.
    * `AES_KEY` – base64 encoded 32 byte key used to encrypt persisted messages. A convenient way to generate one is `openssl rand -base64 32`.
    * Optional `DATABASE_URI` if you want to use a database other than the default SQLite file.
    * Optional `REDIS_URL` for persistent rate limiting and token blocklist storage.
@@ -164,7 +164,7 @@ REACT_APP_API_URL=https://api.example.com npm run build
 ```
 
 Copy the contents of `frontend/build` to the directory served by your HTTP server
-(e.g. the `html` directory for Nginx). Ensure environment variables such as
+(e.g. the `html` directory for Nginx). Ensure **required** environment variables such as
 `JWT_SECRET_KEY`, `AES_KEY` and `DATABASE_URI` are configured on the backend in
 production.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -66,7 +66,10 @@ app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
     'DATABASE_URI', 'sqlite:///secure_messaging.db'
 )
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'change-me')
+_jwt_secret = os.environ.get('JWT_SECRET_KEY')
+if not _jwt_secret:
+    raise RuntimeError('JWT_SECRET_KEY environment variable not set')
+app.config['JWT_SECRET_KEY'] = _jwt_secret
 
 # Initialize database and migration tools
 db = SQLAlchemy(app)

--- a/tests/test_0_missing_jwt.py
+++ b/tests/test_0_missing_jwt.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+import os
+import pytest
+
+
+def test_missing_jwt_secret_key(monkeypatch):
+    """App import should fail when JWT_SECRET_KEY is unset."""
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    sys.modules.pop("backend.app", None)
+    with pytest.raises(RuntimeError):
+        importlib.import_module("backend.app")
+    sys.modules.pop("backend.app", None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.backends import default_backend
 # run without a .env file so we generate a deterministic key on the fly.
 # Generate a deterministic AES key for tests so encryption is repeatable
 os.environ.setdefault("AES_KEY", base64.b64encode(os.urandom(32)).decode())
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 
 from backend.app import app, db, RedisBlocklist
 from backend.models import User


### PR DESCRIPTION
## Summary
- enforce JWT_SECRET_KEY environment variable in `backend/app.py`
- document that JWT_SECRET_KEY is required
- add regression test for missing JWT_SECRET_KEY and update existing tests

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`