### PR TITLE
Align WebSocket CORS settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,9 @@ JWT_SECRET_KEY=your-secret-key
 #POSTGRES_PASSWORD=change-me
 #REDIS_URL=redis://redis:6379/0  # rate limiting and token blocklist
 #SENTRY_DSN=
-#SOCKETIO_ORIGINS=http://localhost:3000
+# Origins allowed for CORS and WebSocket requests. Comma separate multiple
+# values. The default "*" permits any origin.
+#CORS_ORIGINS=http://localhost:3000
 
 # URL for the backend API used by the React frontend
 REACT_APP_API_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ To run the application, follow these steps:
    * `AES_KEY` – base64 encoded 32 byte key used to encrypt persisted messages. A convenient way to generate one is `openssl rand -base64 32`.
    * Optional `DATABASE_URI` if you want to use a database other than the default SQLite file.
    * Optional `REDIS_URL` for persistent rate limiting and token blocklist storage.
-   * Optional `SOCKETIO_ORIGINS` to restrict WebSocket origins.
+   * Optional `CORS_ORIGINS` to restrict allowed origins for both REST and
+     WebSocket connections.
    * Optional push notification settings: `APNS_CERT`, `APNS_TOPIC`,
      `VAPID_PRIVATE_KEY` and `VAPID_SUBJECT`.
 3. Install backend dependencies with `pip install -r requirements.txt`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,12 +35,19 @@ if sentry_dsn:
 # Initialize Flask app and extensions
 app = Flask(__name__)
 
-# Enable Cross-Origin Resource Sharing (CORS) for the app
-CORS(app, supports_credentials=True)
+# Configure allowed origins for CORS and WebSocket connections. A comma
+# separated list in the ``CORS_ORIGINS`` environment variable restricts both
+# Flask and Socket.IO traffic. The default "*" permits all origins.
+_cors_origins = os.environ.get("CORS_ORIGINS", "*")
+if _cors_origins != "*":
+    _cors_origins = [o.strip() for o in _cors_origins.split(",")]
 
-# SocketIO is used for pushing real-time updates to connected clients. Origins
-# can be restricted via the SOCKETIO_ORIGINS environment variable.
-socketio = SocketIO(app, cors_allowed_origins=os.environ.get("SOCKETIO_ORIGINS", "*"))
+# Enable Cross-Origin Resource Sharing (CORS) for the app
+CORS(app, supports_credentials=True, origins=_cors_origins)
+
+# SocketIO is used for pushing real-time updates to connected clients. The same
+# ``CORS_ORIGINS`` setting controls which WebSocket origins are accepted.
+socketio = SocketIO(app, cors_allowed_origins=_cors_origins)
 
 # Initialize rate limiting with a custom key function that prefers the
 # authenticated user id and falls back to the client's IP address.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -808,3 +808,24 @@ def test_message_endpoint_group_membership_required(client):
         headers=headers_b,
     )
     assert resp.status_code == 403
+
+
+def test_cors_origins_applied(monkeypatch):
+    """CORS_ORIGINS should configure both Flask and Socket.IO."""
+    monkeypatch.setenv("CORS_ORIGINS", "http://example.com")
+    import importlib
+    import backend.app as appmod
+    appmod = importlib.reload(appmod)
+
+    client = appmod.app.test_client()
+    resp = client.options(
+        "/api/login",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.headers["Access-Control-Allow-Origin"] == "http://example.com"
+    assert appmod.socketio.server.eio.cors_allowed_origins == [
+        "http://example.com"
+    ]


### PR DESCRIPTION
## Summary
- share `CORS_ORIGINS` between Flask-CORS and Socket.IO
- document the new variable in `.env.example` and README
- test that the value is honored across Flask and Socket.IO

## Testing
- `pytest -q`
- `pytest tests/test_api.py::test_cors_origins_applied -q`