### PR TITLE
Add OpenAPI spec generation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The interface uses the Material-UI component library. It supports a responsive l
 
 # Backend
 The backend is built using Flask and consists of the following resources:
+
+An up-to-date OpenAPI specification can be found in [docs/openapi.yaml](docs/openapi.yaml). Run `python backend/generate_openapi.py` to regenerate the file after modifying the API.
 1. **Register**: Handles user registration by saving user information, hashed passwords, and public keys to the database. It also returns the encrypted private key, salt, and IV to the frontend for storage.
 2. **Login**: Handles user login by verifying the provided username and password, and returns a JWT access token if the credentials are valid.
 3. **Messages**: Handles fetching and storing messages in the database. Messages

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 """Application factory and global objects for the backend."""
 
 import os
-from flask import Flask
+from flask import Flask, send_from_directory
 from flask_restful import Api
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
@@ -16,6 +16,7 @@ from flask_jwt_extended import (
 from flask_jwt_extended.exceptions import JWTExtendedException
 from flask_socketio import SocketIO, disconnect, join_room
 import redis
+from pathlib import Path
 from dotenv import load_dotenv
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -201,6 +202,19 @@ api.add_resource(FileUpload, "/api/files")
 api.add_resource(FileDownload, "/api/files/<int:file_id>")
 api.add_resource(PinnedKeys, "/api/pinned_keys")
 api.add_resource(DeleteAccount, "/api/account")
+# Serve the generated OpenAPI spec and minimal Swagger UI
+@app.route("/api/openapi.yaml")
+def openapi_spec():
+    """Return the OpenAPI specification YAML."""
+    docs_path = Path(__file__).resolve().parent.parent / "docs"
+    return send_from_directory(docs_path, "openapi.yaml")
+
+
+@app.route("/api/docs")
+def api_docs():
+    """Serve an embedded Swagger UI for browsing the API."""
+    return """<!DOCTYPE html><html><head><title>API Docs</title><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css"></head><body><div id="swagger-ui"></div><script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script><script>SwaggerUIBundle({url:"/api/openapi.yaml",dom_id:"#swagger-ui"});</script></body></html>"""
+
 api.add_resource(AccountSettings, "/api/account-settings")
 api.add_resource(RefreshToken, "/api/refresh")
 api.add_resource(RevokeToken, "/api/revoke")

--- a/backend/generate_openapi.py
+++ b/backend/generate_openapi.py
@@ -1,0 +1,513 @@
+"""Generate OpenAPI specification for PrivateLine API using apispec.
+
+This script defines request and response schemas with marshmallow and
+uses apispec to build an OpenAPI 3 specification describing all REST
+endpoints provided by the Flask backend. Running the script writes the
+specification to ``docs/openapi.yaml``.
+"""
+
+import os
+
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+from marshmallow import Schema, fields
+
+
+class RegisterRequestSchema(Schema):
+    """Payload required when registering a new user."""
+
+    username = fields.Str(required=True)
+    email = fields.Email(required=True)
+    password = fields.Str(required=True)
+
+
+class RegisterResponseSchema(Schema):
+    """Values returned after successful registration."""
+
+    encrypted_private_key = fields.Str()
+    salt = fields.Str()
+    nonce = fields.Str()
+    fingerprint = fields.Str()
+
+
+class LoginRequestSchema(Schema):
+    """Credentials used to obtain a JWT token."""
+
+    username = fields.Str(required=True)
+    password = fields.Str(required=True)
+
+
+class LoginResponseSchema(Schema):
+    """Simple schema for the access token response."""
+
+    access_token = fields.Str()
+
+
+class MessageRequestSchema(Schema):
+    """Data required to create a message."""
+
+    content = fields.Str(required=True)
+    recipient = fields.Str(required=False)
+    group_id = fields.Int(required=False)
+    file_id = fields.Int(required=False)
+    signature = fields.Str(required=True)
+
+
+class MessageResponseSchema(Schema):
+    """Data returned when listing messages."""
+
+    id = fields.Int()
+    content = fields.Str()
+    timestamp = fields.Str()
+    sender_id = fields.Int()
+    recipient_id = fields.Int(allow_none=True)
+    file_id = fields.Int(allow_none=True)
+    read = fields.Bool()
+
+
+class GenericMessageSchema(Schema):
+    """Simple message wrapper used for many responses."""
+
+    message = fields.Str()
+
+
+def build_spec() -> APISpec:
+    """Return an APISpec describing all REST endpoints."""
+
+    spec = APISpec(
+        title="PrivateLine API",
+        version="1.0.0",
+        openapi_version="3.0.3",
+        plugins=[MarshmallowPlugin()],
+    )
+
+    # Register schemas so they can be referenced in path definitions
+    spec.components.schema("RegisterRequest", schema=RegisterRequestSchema)
+    spec.components.schema("RegisterResponse", schema=RegisterResponseSchema)
+    spec.components.schema("LoginRequest", schema=LoginRequestSchema)
+    spec.components.schema("LoginResponse", schema=LoginResponseSchema)
+    spec.components.schema("MessageRequest", schema=MessageRequestSchema)
+    spec.components.schema("MessageResponse", schema=MessageResponseSchema)
+    spec.components.schema("GenericMessage", schema=GenericMessageSchema)
+
+    # Each path definition below maps directly to a Flask-RESTful resource.
+    spec.path(
+        path="/api/register",
+        operations={
+            "post": {
+                "summary": "Create a new user",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": "RegisterRequest"
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": "RegisterRequest"
+                        },
+                    },
+                },
+                "responses": {
+                    "201": {
+                        "description": "User created",
+                        "content": {
+                            "application/json": {
+                                "schema": "RegisterResponse"
+                            }
+                        },
+                    },
+                    "400": {"description": "Validation error"},
+                },
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/login",
+        operations={
+            "post": {
+                "summary": "Authenticate and obtain access token",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": "LoginRequest"
+                        }
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "Authentication succeeded",
+                        "content": {
+                            "application/json": {
+                                "schema": "LoginResponse"
+                            }
+                        },
+                    },
+                    "401": {"description": "Invalid credentials"},
+                },
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/messages",
+        operations={
+            "get": {
+                "summary": "Retrieve messages for the user",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {"type": "integer", "default": 50},
+                        "required": False,
+                    },
+                    {
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {"type": "integer", "default": 0},
+                        "required": False,
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of messages",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "messages": {
+                                            "type": "array",
+                                            "items": "MessageResponse",
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+            },
+            "post": {
+                "summary": "Send a new message",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": "MessageRequest"
+                        },
+                        "multipart/form-data": {
+                            "schema": "MessageRequest"
+                        },
+                    },
+                },
+                "responses": {
+                    "201": {"description": "Message stored"},
+                    "400": {"description": "Invalid input"},
+                },
+            },
+        },
+    )
+
+    spec.path(
+        path="/api/public_key/{username}",
+        operations={
+            "get": {
+                "summary": "Return public key for user",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "username",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Public key retrieved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"public_key": {"type": "string"}},
+                                }
+                            }
+                        },
+                    },
+                    "404": {"description": "User not found"},
+                },
+            }
+        },
+    )
+
+    # Additional endpoints are described more generically to keep the
+    # specification concise. Only the most relevant parameters and response
+    # structures are documented explicitly.
+
+    spec.path(
+        path="/api/users",
+        operations={
+            "get": {
+                "summary": "List usernames",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {"type": "string"},
+                        "required": False,
+                    }
+                ],
+                "responses": {"200": {"description": "User list"}},
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/groups",
+        operations={
+            "get": {"summary": "List chat groups", "responses": {"200": {"description": "Group list"}}},
+            "post": {"summary": "Create group", "responses": {"201": {"description": "Group created"}}},
+        },
+    )
+
+    spec.path(
+        path="/api/groups/{group_id}/members",
+        operations={
+            "post": {
+                "summary": "Join or invite user",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "group_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "responses": {"201": {"description": "Added"}, "403": {"description": "Not a member"}},
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/groups/{group_id}/members/{user_id}",
+        operations={
+            "delete": {
+                "summary": "Remove a member",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "group_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    },
+                    {
+                        "in": "path",
+                        "name": "user_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    },
+                ],
+                "responses": {"200": {"description": "Removed"}},
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/groups/{group_id}/key",
+        operations={
+            "get": {
+                "summary": "Retrieve group key",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "group_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "responses": {"200": {"description": "Key returned"}},
+            },
+            "put": {
+                "summary": "Rotate group key",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "group_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "responses": {"200": {"description": "Key rotated"}},
+            },
+        },
+    )
+
+    spec.path(
+        path="/api/groups/{group_id}/messages",
+        operations={
+            "get": {
+                "summary": "List group messages",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "group_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    },
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {"type": "integer", "default": 50},
+                        "required": False,
+                    },
+                    {
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {"type": "integer", "default": 0},
+                        "required": False,
+                    },
+                ],
+                "responses": {"200": {"description": "Messages returned"}},
+            },
+            "post": {
+                "summary": "Send group message",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "group_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {"schema": "MessageRequest"}
+                    },
+                },
+                "responses": {"201": {"description": "Message stored"}},
+            },
+        },
+    )
+
+    spec.path(
+        path="/api/files",
+        operations={
+            "post": {
+                "summary": "Upload encrypted file",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"file": {"type": "string", "format": "binary"}},
+                                "required": ["file"],
+                            }
+                        }
+                    },
+                },
+                "responses": {"201": {"description": "File stored"}},
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/files/{file_id}",
+        operations={
+            "get": {
+                "summary": "Download file",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "file_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "responses": {"200": {"description": "File contents"}},
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/pinned_keys",
+        operations={
+            "get": {"summary": "List pinned keys", "responses": {"200": {"description": "List returned"}}},
+            "post": {"summary": "Store pinned key", "responses": {"200": {"description": "Stored"}}},
+        },
+    )
+
+    spec.path(
+        path="/api/account",
+        operations={"delete": {"summary": "Delete account", "responses": {"200": {"description": "Deleted"}}}},
+    )
+
+    spec.path(
+        path="/api/account-settings",
+        operations={"put": {"summary": "Update account", "responses": {"200": {"description": "Updated"}}}},
+    )
+
+    spec.path(
+        path="/api/refresh",
+        operations={"post": {"summary": "Refresh JWT", "responses": {"200": {"description": "Token issued"}}}},
+    )
+
+    spec.path(
+        path="/api/revoke",
+        operations={"post": {"summary": "Revoke JWT", "responses": {"200": {"description": "Revoked"}}}},
+    )
+
+    spec.path(
+        path="/api/push-token",
+        operations={
+            "post": {"summary": "Store push token", "responses": {"200": {"description": "Stored"}}},
+            "delete": {"summary": "Delete push token", "responses": {"200": {"description": "Deleted"}}},
+        },
+    )
+
+    spec.path(
+        path="/api/messages/{message_id}",
+        operations={
+            "delete": {
+                "summary": "Delete message",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "message_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "responses": {"200": {"description": "Deleted"}},
+            }
+        },
+    )
+
+    spec.path(
+        path="/api/messages/{message_id}/read",
+        operations={
+            "post": {
+                "summary": "Mark message as read",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "message_id",
+                        "schema": {"type": "integer"},
+                        "required": True,
+                    }
+                ],
+                "responses": {"200": {"description": "Marked as read"}},
+            }
+        },
+    )
+
+    return spec
+
+
+if __name__ == "__main__":
+    spec = build_spec()
+    os.makedirs("docs", exist_ok=True)
+    with open(os.path.join("docs", "openapi.yaml"), "w") as fh:
+        fh.write(spec.to_yaml())
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,6 @@ fakeredis>=2.21
 # WSGI server
 gunicorn
 gevent
+apispec>=6.8
+marshmallow>=4.0
+PyYAML>=6.0

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,409 @@
+paths:
+  /api/register:
+    post:
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterResponse'
+        '400':
+          description: Validation error
+  /api/login:
+    post:
+      summary: Authenticate and obtain access token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authentication succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '401':
+          description: Invalid credentials
+  /api/messages:
+    get:
+      summary: Retrieve messages for the user
+      parameters:
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          default: 50
+        required: false
+      - in: query
+        name: offset
+        schema:
+          type: integer
+          default: 0
+        required: false
+      responses:
+        '200':
+          description: List of messages
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MessageResponse'
+    post:
+      summary: Send a new message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MessageRequest'
+      responses:
+        '201':
+          description: Message stored
+        '400':
+          description: Invalid input
+  /api/public_key/{username}:
+    get:
+      summary: Return public key for user
+      parameters:
+      - in: path
+        name: username
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Public key retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  public_key:
+                    type: string
+        '404':
+          description: User not found
+  /api/users:
+    get:
+      summary: List usernames
+      parameters:
+      - in: query
+        name: q
+        schema:
+          type: string
+        required: false
+      responses:
+        '200':
+          description: User list
+  /api/groups:
+    get:
+      summary: List chat groups
+      responses:
+        '200':
+          description: Group list
+    post:
+      summary: Create group
+      responses:
+        '201':
+          description: Group created
+  /api/groups/{group_id}/members:
+    post:
+      summary: Join or invite user
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '201':
+          description: Added
+        '403':
+          description: Not a member
+  /api/groups/{group_id}/members/{user_id}:
+    delete:
+      summary: Remove a member
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '200':
+          description: Removed
+  /api/groups/{group_id}/key:
+    get:
+      summary: Retrieve group key
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '200':
+          description: Key returned
+    put:
+      summary: Rotate group key
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '200':
+          description: Key rotated
+  /api/groups/{group_id}/messages:
+    get:
+      summary: List group messages
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          default: 50
+        required: false
+      - in: query
+        name: offset
+        schema:
+          type: integer
+          default: 0
+        required: false
+      responses:
+        '200':
+          description: Messages returned
+    post:
+      summary: Send group message
+      parameters:
+      - in: path
+        name: group_id
+        schema:
+          type: integer
+        required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageRequest'
+      responses:
+        '201':
+          description: Message stored
+  /api/files:
+    post:
+      summary: Upload encrypted file
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+              required:
+              - file
+      responses:
+        '201':
+          description: File stored
+  /api/files/{file_id}:
+    get:
+      summary: Download file
+      parameters:
+      - in: path
+        name: file_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '200':
+          description: File contents
+  /api/pinned_keys:
+    get:
+      summary: List pinned keys
+      responses:
+        '200':
+          description: List returned
+    post:
+      summary: Store pinned key
+      responses:
+        '200':
+          description: Stored
+  /api/account:
+    delete:
+      summary: Delete account
+      responses:
+        '200':
+          description: Deleted
+  /api/account-settings:
+    put:
+      summary: Update account
+      responses:
+        '200':
+          description: Updated
+  /api/refresh:
+    post:
+      summary: Refresh JWT
+      responses:
+        '200':
+          description: Token issued
+  /api/revoke:
+    post:
+      summary: Revoke JWT
+      responses:
+        '200':
+          description: Revoked
+  /api/push-token:
+    post:
+      summary: Store push token
+      responses:
+        '200':
+          description: Stored
+    delete:
+      summary: Delete push token
+      responses:
+        '200':
+          description: Deleted
+  /api/messages/{message_id}:
+    delete:
+      summary: Delete message
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '200':
+          description: Deleted
+  /api/messages/{message_id}/read:
+    post:
+      summary: Mark message as read
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '200':
+          description: Marked as read
+info:
+  title: PrivateLine API
+  version: 1.0.0
+openapi: 3.0.3
+components:
+  schemas:
+    RegisterRequest:
+      type: object
+      properties:
+        username:
+          type: string
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+      required:
+      - email
+      - password
+      - username
+    RegisterResponse:
+      type: object
+      properties:
+        encrypted_private_key:
+          type: string
+        salt:
+          type: string
+        nonce:
+          type: string
+        fingerprint:
+          type: string
+    LoginRequest:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+      required:
+      - password
+      - username
+    LoginResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+    MessageRequest:
+      type: object
+      properties:
+        content:
+          type: string
+        recipient:
+          type: string
+        group_id:
+          type: integer
+        file_id:
+          type: integer
+        signature:
+          type: string
+      required:
+      - content
+      - signature
+    MessageResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        content:
+          type: string
+        timestamp:
+          type: string
+        sender_id:
+          type: integer
+        recipient_id:
+          type: integer
+          nullable: true
+        file_id:
+          type: integer
+          nullable: true
+        read:
+          type: boolean
+    GenericMessage:
+      type: object
+      properties:
+        message:
+          type: string


### PR DESCRIPTION
## Summary
- generate OpenAPI spec via `apispec`
- host Swagger UI routes
- document the spec in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`