### PR TITLE
Add contribution guide and OpenAPI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           profile: minimal
           override: true
       - run: pip install -r backend/requirements.txt
+      - name: Generate OpenAPI spec
+        run: python backend/generate_openapi.py
+      - name: Verify OpenAPI spec committed
+        run: git diff --exit-code docs/openapi.yaml
       - run: pytest
 
   frontend:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to PrivateLine
+
+This guide explains how to set up a local development environment and the coding standards used for the project. Following these steps ensures a consistent workflow for all contributors.
+
+## Prerequisites
+
+- **Python 3.11**
+- **Node.js 18**
+- **Xcode 15** if building the iOS client
+- `git` and `Docker` for optional containerized workflows
+
+## Setup
+
+1. Install Python dependencies:
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+2. Install frontend dependencies:
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+3. (Optional) Build the iOS project in `ios/` with Xcode.
+
+4. Run the unit tests to verify your environment:
+
+   ```bash
+   pytest
+   npm test --if-present --prefix frontend
+   ```
+
+## Code Style
+
+Python code follows **PEP8** using `flake8` for linting. JavaScript code follows the default ESLint rules created by `create-react-app`. Swift code follows standard Apple conventions. Please run formatters or linters when available.
+
+## Updating the OpenAPI Specification
+
+API changes require regenerating `docs/openapi.yaml`:
+
+```bash
+python backend/generate_openapi.py
+```
+
+The CI workflow runs this script and fails if the generated file differs from what is committed. Be sure to run the command and commit the updated file whenever you modify backend endpoints.
+

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,7 @@
+"""Backend package for the PrivateLine application.
+
+This package exposes the Flask app along with helper modules so they can be
+imported as ``backend.<module>``. The file itself is intentionally minimal and
+serves only to mark ``backend`` as a package.
+"""
+


### PR DESCRIPTION
## Summary
- document setup process in CONTRIBUTING.md and explain OpenAPI workflow
- add simple module docstring to `backend/__init__.py`
- fail CI when `docs/openapi.yaml` is not regenerated

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68640a5811548321825140e8caf9e23c