### PR TITLE
Add unread count API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ See [docs/architecture.md](docs/architecture.md) for a high-level overview of ho
 - Optional dark mode and push notification support on iOS
 - Ephemeral messages with automatic expiration handling
 - Smooth animated chat interface for the React frontend
+- Unread message count endpoint for quick status checks. Use ``GET /api/unread_count``
+  to retrieve the total number of unread direct and group messages for the
+  authenticated user.
 
 ## Ephemeral messages and offline caching
 
@@ -57,6 +60,7 @@ An up-to-date OpenAPI specification can be found in [docs/openapi.yaml](docs/ope
    0 respectively.
 4. **RefreshToken**: Issues a new JWT for an authenticated user when called with a valid token.
 5. **RevokeToken**: Revokes the current JWT so it can no longer be used.
+6. **UnreadCount**: Returns the number of unread messages for the current user.
 
 The backend also includes rate limiting on message sending, JWT-based user authentication, and CORS configuration.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -190,6 +190,7 @@ from .resources import (
     PushTokenResource,
     MessageResource,
     MessageRead,
+    UnreadCount,
 )
 
 
@@ -254,6 +255,7 @@ api.add_resource(RevokeToken, "/api/revoke")
 api.add_resource(PushTokenResource, "/api/push-token")
 api.add_resource(MessageResource, "/api/messages/<int:message_id>")
 api.add_resource(MessageRead, "/api/messages/<int:message_id>/read")
+api.add_resource(UnreadCount, "/api/unread_count")
 
 # Run the development server only when executed directly.
 if __name__ == "__main__":

--- a/backend/generate_openapi.py
+++ b/backend/generate_openapi.py
@@ -507,6 +507,17 @@ def build_spec() -> APISpec:
         },
     )
 
+    spec.path(
+        path="/api/unread_count",
+        operations={
+            "get": {
+                "summary": "Get unread message count",
+                "description": "Return the number of unread direct and group messages for the authenticated user.",
+                "responses": {"200": {"description": "Count returned"}},
+            }
+        },
+    )
+
     return spec
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -321,6 +321,14 @@ paths:
       responses:
         '200':
           description: Marked as read
+  /api/unread_count:
+    get:
+      summary: Get unread message count
+      description: Return the number of unread direct and group messages for the authenticated
+        user.
+      responses:
+        '200':
+          description: Count returned
 info:
   title: PrivateLine API
   version: 1.0.0


### PR DESCRIPTION
## Summary
- track unread message totals via `/api/unread_count`
- document the new feature and endpoint
- regenerate OpenAPI spec
- test unread count behavior

## Testing
- `pytest -q`