### PR TITLE
Implement Argon2 password hashing with backward compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ Flask-Limiter==1.4
 Flask-JWT-Extended==4.3.1
 Flask-SocketIO==5.3.2
 python-dotenv==0.21.0
+argon2-cffi>=23.1
 cryptography==36.0.1
 Werkzeug==2.1.1
 itsdangerous==2.1.1


### PR DESCRIPTION
## Summary
- upgrade backend auth logic to hash passwords with Argon2
- keep compatibility for existing PBKDF2 hashes via `verify_password`
- update account settings to use Argon2 when changing passwords
- add argon2-cffi dependency
- test login for legacy PBKDF2 credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867287ebfbc8321895d0ac02e60a343