### PR TITLE
Add Curve25519 E2E encryption helpers and password channels

### DIFF
--- a/backend/crypto_e2e.py
+++ b/backend/crypto_e2e.py
@@ -1,0 +1,129 @@
+"""Utilities for Curve25519-based end-to-end encryption.
+
+This module exposes helpers used by the application to perform E2E
+encryption and decryption using ephemeral Curve25519 key exchange and
+AES-GCM for the symmetric cipher. The intent is that messages are
+encrypted client-side before being transmitted to the server. The server
+simply stores the ciphertext.
+
+Example usage:
+
+>>> priv_a, pub_a = generate_keypair()
+>>> priv_b, pub_b = generate_keypair()
+>>> enc = encrypt_message(b"hi", pub_b)
+>>> msg = decrypt_message(enc, priv_b)
+>>> assert msg == b"hi"
+
+The ``encrypt_message`` function returns a dictionary containing the
+base64 encoded ciphertext, nonce, and ephemeral public key. The receiver
+uses ``decrypt_message`` with their private key to recover the plaintext.
+
+Design notes:
+- HKDF derives a 32-byte AES key from the shared secret.
+- A new ephemeral key is generated for every encryption operation to
+  provide forward secrecy.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Dict
+import os
+
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import serialization
+
+
+@dataclass
+class EncryptedMessage:
+    """Container holding encrypted message fields."""
+
+    ciphertext_b64: str
+    nonce_b64: str
+    ephemeral_pub_b64: str
+
+
+def generate_keypair() -> tuple[X25519PrivateKey, str]:
+    """Return a new Curve25519 private key and its public component.
+
+    The public key is encoded using base64 for easy transport. The private
+    key object is returned directly as it is used for decryption.
+    """
+
+    priv = X25519PrivateKey.generate()
+    pub = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return priv, base64.b64encode(pub).decode()
+
+
+def _derive_aes_key(shared: bytes) -> bytes:
+    """Derive a 256-bit AES key from the ECDH shared secret."""
+
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"e2e-msg",
+    )
+    return hkdf.derive(shared)
+
+
+def encrypt_message(plaintext: bytes, recipient_pub_b64: str) -> EncryptedMessage:
+    """Encrypt ``plaintext`` for ``recipient_pub_b64``.
+
+    Parameters
+    ----------
+    plaintext:
+        Raw bytes to encrypt.
+    recipient_pub_b64:
+        Base64 encoded public key of the recipient.
+
+    Returns
+    -------
+    EncryptedMessage
+        Object containing base64 fields required for decryption.
+    """
+
+    recipient_pub = X25519PublicKey.from_public_bytes(base64.b64decode(recipient_pub_b64))
+    ephemeral_priv = X25519PrivateKey.generate()
+    shared = ephemeral_priv.exchange(recipient_pub)
+    aes_key = _derive_aes_key(shared)
+
+    aes = AESGCM(aes_key)
+    nonce = os.urandom(12)
+    ciphertext = aes.encrypt(nonce, plaintext, None)
+
+    return EncryptedMessage(
+        ciphertext_b64=base64.b64encode(ciphertext).decode(),
+        nonce_b64=base64.b64encode(nonce).decode(),
+        ephemeral_pub_b64=base64.b64encode(
+            ephemeral_priv.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        ).decode(),
+    )
+
+
+def decrypt_message(data: EncryptedMessage, recipient_priv: X25519PrivateKey) -> bytes:
+    """Return the decrypted plaintext for ``data`` using ``recipient_priv``."""
+
+    ephemeral_pub = X25519PublicKey.from_public_bytes(
+        base64.b64decode(data.ephemeral_pub_b64)
+    )
+    shared = recipient_priv.exchange(ephemeral_pub)
+    aes_key = _derive_aes_key(shared)
+
+    aes = AESGCM(aes_key)
+    nonce = base64.b64decode(data.nonce_b64)
+    ciphertext = base64.b64decode(data.ciphertext_b64)
+    return aes.decrypt(nonce, ciphertext, None)

--- a/backend/password_channel.py
+++ b/backend/password_channel.py
@@ -1,0 +1,64 @@
+"""Password protected channels built on AES encryption.
+
+A password channel is a lightweight construct that allows two or more
+users to exchange messages encrypted with a key derived from a shared
+password. Channels do not persist in the database in this simplified
+implementation; instead ``PasswordChannel`` merely exposes helper
+functions for deriving keys and encrypting/decrypting payloads.
+
+The key is derived via PBKDF2-HMAC-SHA256 using a random salt. The
+channel participants must remember the password and salt in order to
+communicate.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+@dataclass
+class PasswordChannel:
+    """Represents a channel protected by a password."""
+
+    salt_b64: str
+    iterations: int = 200_000
+
+    def _derive_key(self, password: str) -> bytes:
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=base64.b64decode(self.salt_b64),
+            iterations=self.iterations,
+        )
+        return kdf.derive(password.encode())
+
+    @classmethod
+    def create(cls) -> "PasswordChannel":
+        """Return a new channel with a random salt."""
+        salt = os.urandom(16)
+        return cls(base64.b64encode(salt).decode())
+
+    def encrypt(self, password: str, plaintext: bytes) -> tuple[str, str]:
+        """Encrypt ``plaintext`` using ``password``.
+
+        Returns a tuple ``(nonce_b64, ciphertext_b64)``.
+        """
+        key = self._derive_key(password)
+        nonce = os.urandom(12)
+        aes = AESGCM(key)
+        ct = aes.encrypt(nonce, plaintext, None)
+        return base64.b64encode(nonce).decode(), base64.b64encode(ct).decode()
+
+    def decrypt(self, password: str, nonce_b64: str, ct_b64: str) -> bytes:
+        """Decrypt ``ct_b64`` with the given ``password``."""
+        key = self._derive_key(password)
+        aes = AESGCM(key)
+        nonce = base64.b64decode(nonce_b64)
+        ct = base64.b64decode(ct_b64)
+        return aes.decrypt(nonce, ct, None)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,23 @@
+import base64
+from backend.crypto_e2e import generate_keypair, encrypt_message, decrypt_message
+from backend.password_channel import PasswordChannel
+
+
+def test_curve25519_e2e_roundtrip():
+    """Encryption and decryption with Curve25519 should round-trip."""
+    priv_a, pub_a = generate_keypair()
+    priv_b, pub_b = generate_keypair()
+
+    msg = b"secret"
+    enc = encrypt_message(msg, pub_b)
+    dec = decrypt_message(enc, priv_b)
+    assert dec == msg
+
+
+def test_password_channel_encryption():
+    """Password channels encrypt and decrypt data symmetrically."""
+    channel = PasswordChannel.create()
+    password = "hunter2"
+    nonce, ct = channel.encrypt(password, b"top")
+    pt = channel.decrypt(password, nonce, ct)
+    assert pt == b"top"


### PR DESCRIPTION
## Summary
- implement utility module `crypto_e2e` for Curve25519 + AES-GCM E2E encryption
- implement simple `PasswordChannel` class providing password-protected AES channels
- add tests verifying the new encryption helpers

## Testing
- `pytest tests/test_crypto.py::test_curve25519_e2e_roundtrip -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c810c10fc83219b46aa8dd6a14aea