### PR TITLE
Implement orphan file cleanup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -154,6 +154,9 @@ def clean_expired_messages() -> None:
             for msg in expired:
                 db.session.delete(msg)
             db.session.commit()
+            from .resources import remove_orphan_files
+
+            remove_orphan_files()
 
 
 scheduler.add_job(clean_expired_messages, "interval", minutes=1)


### PR DESCRIPTION
## Summary
- add `remove_orphan_files` helper in backend resources
- trigger file cleanup when deleting messages, accounts, or expired messages
- test removal by deleting a message that referenced an upload

## Testing
- `pytest tests/test_files.py::test_file_removed_with_message -q`
- `pytest -q` *(fails: test_group_messages_pagination, test_messages_pagination)*