### PR TITLE
Add push token TTL cleanup job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,9 @@ REACT_APP_API_URL=http://localhost:5000
 # Firebase Cloud Messaging server key for Android push notifications
 #FCM_SERVER_KEY=
 
+# Days before stored push tokens are considered expired and purged by the
+# cleanup job. The default of 30 keeps tokens for about a month.
+#PUSH_TOKEN_TTL_DAYS=30
+
 # Override the default 5MB upload limit
 #MAX_FILE_SIZE=5242880


### PR DESCRIPTION
## Summary
- timestamp push tokens on create
- purge stale push tokens with a scheduler
- document PUSH_TOKEN_TTL_DAYS option
- test token cleanup logic

## Testing
- `pytest -q` *(fails: test_push_token_cleanup, test_group_messages_pagination, test_messages_pagination)*

------
https://chatgpt.com/codex/tasks/task_e_686c9495fe6c8321af1246c96c81db8e