### PR TITLE
Add logging configuration with rotation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -45,6 +45,10 @@ if sentry_dsn:
 
 # Initialize Flask app and extensions
 app = Flask(__name__)
+# Initialize application-wide logging before other components.
+from .logging_config import init_logging
+init_logging()
+
 
 # Configure allowed origins for CORS and WebSocket connections. A comma
 # separated list in the ``CORS_ORIGINS`` environment variable restricts both

--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -1,0 +1,60 @@
+"""Logging utilities for the PrivateLine backend.
+
+This module configures Python's :mod:`logging` subsystem with a
+:class:`~logging.handlers.TimedRotatingFileHandler` so log files rotate at
+midnight. The number of retained backups is controlled by the
+``LOG_RETENTION_DAYS`` environment variable. A small filter removes common
+PII such as bearer tokens and email addresses before messages are written.
+
+Example usage::
+
+    from backend.logging_config import init_logging
+    init_logging()
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+
+class SensitiveDataFilter(logging.Filter):
+    """Sanitize log messages to avoid leaking tokens or email addresses."""
+
+    _token_re = re.compile(r"Bearer\s+[A-Za-z0-9._-]+")
+    _email_re = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        sanitized = self._token_re.sub("Bearer [REDACTED]", message)
+        sanitized = self._email_re.sub("[REDACTED_EMAIL]", sanitized)
+        if sanitized != message:
+            record.msg = sanitized
+            record.args = ()
+        return True
+
+
+def init_logging() -> None:
+    """Initialize the root logger with a rotating file handler."""
+
+    log_path = Path(os.environ.get("LOG_PATH", "/tmp/private_line.log"))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    retention = int(os.environ.get("LOG_RETENTION_DAYS", "7"))
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    handler = TimedRotatingFileHandler(
+        filename=str(log_path), when="midnight", backupCount=retention
+    )
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s - %(message)s")
+    )
+    handler.addFilter(SensitiveDataFilter())
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+    root.addHandler(handler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,47 @@
+"""Unit tests for the logging configuration."""
+
+import logging
+from pathlib import Path
+
+from backend.logging_config import init_logging
+
+
+def test_log_file_retention(tmp_path, monkeypatch):
+    """Old log files beyond the retention limit should be removed."""
+    log = tmp_path / "app.log"
+    monkeypatch.setenv("LOG_PATH", str(log))
+    monkeypatch.setenv("LOG_RETENTION_DAYS", "1")
+
+    logging.getLogger().handlers.clear()
+    init_logging()
+    logger = logging.getLogger("test")
+    handler = logging.getLogger().handlers[0]
+
+    logger.info("first")
+    handler.doRollover()
+    logger.info("second")
+    handler.doRollover()
+    logger.info("third")
+
+    rotated = list(log.parent.glob("app.log.*"))
+    assert len(rotated) == 1
+
+
+def test_sensitive_data_redacted(tmp_path, monkeypatch):
+    """Tokens and email addresses should be redacted from logs."""
+    log = tmp_path / "app.log"
+    monkeypatch.setenv("LOG_PATH", str(log))
+
+    logging.getLogger().handlers.clear()
+    init_logging()
+    logger = logging.getLogger("test")
+
+    logger.info("Authorization: Bearer abc.def user@example.com")
+    handler = logging.getLogger().handlers[0]
+    handler.flush()
+
+    content = Path(log).read_text()
+    assert "abc.def" not in content
+    assert "user@example.com" not in content
+    assert "Bearer [REDACTED]" in content
+    assert "[REDACTED_EMAIL]" in content


### PR DESCRIPTION
## Summary
- add `logging_config.py` providing timed file rotation and sensitive data filtering
- initialize logging in `app.py`
- ensure logs redact bearer tokens and emails
- add unit tests covering retention and redaction

## Testing
- `pytest tests/test_logging.py::test_log_file_retention -q`
- `pytest tests/test_logging.py::test_sensitive_data_redacted -q`
- `pytest -q` *(fails: test_push_token_cleanup, test_group_messages_pagination, test_messages_pagination)*