### PR TITLE
Encrypt push tokens

### DIFF
--- a/backend/resources.py
+++ b/backend/resources.py
@@ -1013,7 +1013,8 @@ class PushTokenResource(Resource):
 
         platform = data.get("platform", "ios")
         user_id = int(get_jwt_identity())
-        pt = PushToken.query.filter_by(user_id=user_id, token=token).first()
+        enc = PushToken.encrypt_value(token)
+        pt = PushToken.query.filter_by(user_id=user_id, token=enc).first()
         if pt:
             pt.platform = platform
         else:
@@ -1035,7 +1036,8 @@ class PushTokenResource(Resource):
             return {"message": "Token is required."}, 400
 
         user_id = int(get_jwt_identity())
-        pt = PushToken.query.filter_by(user_id=user_id, token=token).first()
+        enc = PushToken.encrypt_value(token)
+        pt = PushToken.query.filter_by(user_id=user_id, token=enc).first()
         if pt:
             db.session.delete(pt)
             try:

--- a/migrations/versions/2c_encrypt_push_tokens.py
+++ b/migrations/versions/2c_encrypt_push_tokens.py
@@ -1,0 +1,57 @@
+"""Data migration to encrypt stored push notification tokens.
+
+Existing tokens are read in plaintext, encrypted using the same AES-GCM
+mechanism employed by :class:`backend.models.PushToken`, and written back to
+the ``push_token`` table. The migration requires the ``AES_KEY`` environment
+variable to be present so the ciphertext can be generated deterministically.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from base64 import b64decode, b64encode
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from hashlib import sha256
+import os
+
+revision = '2c'
+down_revision = '1b'
+branch_labels = None
+depends_on = None
+
+
+def _aesgcm():
+    key_b64 = os.environ.get('AES_KEY')
+    if not key_b64:
+        raise RuntimeError('AES_KEY environment variable not set')
+    return AESGCM(b64decode(key_b64))
+
+
+def upgrade():
+    """Encrypt all rows in the ``push_token`` table."""
+    conn = op.get_bind()
+    aes = _aesgcm()
+    tokens = conn.execute(sa.text("SELECT id, token FROM push_token")).fetchall()
+    for tid, plaintext in tokens:
+        nonce = sha256(plaintext.encode()).digest()[:12]
+        ct = aes.encrypt(nonce, plaintext.encode(), None)
+        enc = b64encode(nonce + ct).decode()
+        conn.execute(
+            sa.text("UPDATE push_token SET token=:t WHERE id=:i"),
+            {"t": enc, "i": tid},
+        )
+
+
+def downgrade():
+    """Revert tokens back to plaintext form."""
+    conn = op.get_bind()
+    aes = _aesgcm()
+    tokens = conn.execute(sa.text("SELECT id, token FROM push_token")).fetchall()
+    for tid, enc in tokens:
+        raw = b64decode(enc)
+        nonce, ct = raw[:12], raw[12:]
+        plain = aes.decrypt(nonce, ct, None).decode()
+        conn.execute(
+            sa.text("UPDATE push_token SET token=:t WHERE id=:i"),
+            {"t": plain, "i": tid},
+        )
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,16 @@ def reset_rate_limits():
     limiter.reset()
 
 
+@pytest.fixture(autouse=True)
+def reset_ratchet():
+    """Clear the in-memory ratchet store between tests."""
+    import backend.ratchet as ratchet
+
+    ratchet._store = None
+    yield
+    ratchet._store = None
+
+
 @pytest.fixture
 def client():
     """Flask test client with an isolated SQLite database."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -243,7 +243,8 @@ def test_push_token_delete(client):
     resp = client.delete("/api/push-token", json={"token": "tok"}, headers=headers)
     assert resp.status_code == 200
     with app.app_context():
-        assert PushToken.query.filter_by(token="tok").first() is None
+        enc = PushToken.encrypt_value("tok")
+        assert PushToken.query.filter_by(token=enc).first() is None
 
 
 def test_push_token_cleanup(monkeypatch, client):
@@ -264,7 +265,8 @@ def test_push_token_cleanup(monkeypatch, client):
     clean_expired_push_tokens()
 
     with app.app_context():
-        assert PushToken.query.filter_by(token="oldtok").first() is None
+        enc = PushToken.encrypt_value("oldtok")
+        assert PushToken.query.filter_by(token=enc).first() is None
 
 
 def test_users_endpoint(client):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,6 +1,15 @@
 """Push notification helper tests."""
 
 import backend.resources as res
+from backend.models import PushToken
+
+
+def test_push_token_encryption_roundtrip():
+    """Tokens should encrypt and decrypt transparently."""
+    plaintext = "tok123"
+    enc = PushToken.encrypt_value(plaintext)
+    assert plaintext == PushToken.decrypt_value(enc)
+    assert enc != plaintext
 
 
 def test_fcm_request(monkeypatch):
@@ -21,4 +30,22 @@ def test_fcm_request(monkeypatch):
     assert called['url'] == 'https://fcm.googleapis.com/fcm/send'
     assert called['json']['to'] == 'token123'
     assert called['headers']['Authorization'] == 'key=secret'
+
+
+def test_push_token_db_encrypted(client):
+    """Stored tokens should not be plaintext in the database."""
+    from .conftest import register_user, login_user
+    from backend.app import app
+
+    register_user(client, "alice")
+    token = login_user(client, "alice").get_json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    client.post(
+        "/api/push-token", json={"token": "abc", "platform": "web"}, headers=headers
+    )
+
+    with app.app_context():
+        pt = PushToken.query.first()
+        assert pt.token == "abc"
+        assert pt.token_ciphertext != "abc"
 


### PR DESCRIPTION
## Summary
- encrypt push tokens using AES-GCM
- allow PushTokenResource to handle encrypted tokens
- re-encrypt existing tokens via Alembic migration
- reset ratchet store between tests
- validate push-token encryption in tests

## Testing
- `pytest tests/test_push.py -q`
- `pytest -q` *(fails: cryptography.exceptions.InvalidTag in message pagination tests)*