### PR TITLE
Implement file retention policy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,10 @@
 import os
 import base64
 import io
+
+# Flag that ensures the Flask app does not start background schedulers when
+# imported for the test suite.
+os.environ.setdefault("TESTING", "1")
 import pytest
 from base64 import b64decode
 from cryptography.hazmat.primitives import hashes


### PR DESCRIPTION
## Summary
- add FILE_RETENTION_DAYS configuration and `file_retention_days` field
- track `created_at` for uploaded files
- scheduled job removes expired files
- skip scheduler start during tests via TESTING env flag
- tests cover pruning logic

## Testing
- `pytest -q` *(fails: cryptography.exceptions.InvalidTag)*