### PR TITLE
Implement conversation-level retention policy

### DIFF
--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -299,6 +299,28 @@ function Chat() {
   const [users, setUsers] = useState([]);
   const [selectedGroup, setSelectedGroup] = useState(null);
   const [file, setFile] = useState(null);
+  // Per-conversation TTL in days. Empty string leaves the setting unchanged.
+  const [convRetention, setConvRetention] = useState('');
+
+  /**
+   * Update the server-side retention policy for the active conversation.
+   */
+  const updateRetention = async () => {
+    try {
+      if (selectedGroup) {
+        await api.put(`/api/groups/${selectedGroup}/retention`, {
+          retention_days: parseInt(convRetention, 10),
+        });
+      } else if (recipient) {
+        await api.put(`/api/conversations/${recipient}/retention`, {
+          retention_days: parseInt(convRetention, 10),
+        });
+      }
+      setConvRetention('');
+    } catch (err) {
+      console.error('Failed to set retention', err);
+    }
+  };
   // Element at the end of the message list so we can smoothly scroll
   const messageEndRef = useRef(null);
 
@@ -692,6 +714,18 @@ function Chat() {
               sx={{ width: 120, ml: 1 }}
               inputProps={{ min: 0 }}
             />
+            <TextField
+              type="number"
+              placeholder="Retention days"
+              value={convRetention}
+              onChange={(e) => setConvRetention(e.target.value)}
+              size="small"
+              sx={{ width: 120, ml: 1 }}
+              inputProps={{ min: 1, max: 365 }}
+            />
+            <Button onClick={updateRetention} variant="outlined" sx={{ ml: 1 }}>
+              Set TTL
+            </Button>
             <input type="file" onChange={(e) => setFile(e.target.files[0])} />
             <Button type="submit" variant="contained" sx={{ ml: 1 }}>
               Send

--- a/migrations/versions/3d_conversation_retention.py
+++ b/migrations/versions/3d_conversation_retention.py
@@ -1,0 +1,28 @@
+"""Add group retention and conversation-specific TTL"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '3d'
+down_revision = '2c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('group', sa.Column('retention_days', sa.Integer(), nullable=True))
+    op.create_table(
+        'conversation_retention',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('owner_id', sa.Integer(), nullable=False),
+        sa.Column('peer_id', sa.Integer(), nullable=False),
+        sa.Column('retention_days', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['owner_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['peer_id'], ['user.id']),
+        sa.UniqueConstraint('owner_id', 'peer_id', name='uix_conv_retention'),
+    )
+
+
+def downgrade():
+    op.drop_table('conversation_retention')
+    op.drop_column('group', 'retention_days')


### PR DESCRIPTION
## Summary
- add `retention_days` to `Group` and new `ConversationRetention` table
- respect custom TTL when retrieving and cleaning messages
- expose `/api/groups/<id>/retention` and `/api/conversations/<user>/retention`
- allow chat UI to set per-conversation TTL
- test conversation overrides of retention policy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / RuntimeError)*