### PR TITLE
Expand test coverage for failure cases

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,4 +1,12 @@
+"""Cryptography helper tests.
+
+These unit tests exercise the helper routines used for end-to-end encryption.
+They confirm that normal encryption/decryption succeeds and that tampering or
+using the wrong key fails as expected. Run with ``pytest``.
+"""
+
 import base64
+import pytest
 from backend.crypto_e2e import generate_keypair, encrypt_message, decrypt_message
 from backend.password_channel import PasswordChannel
 
@@ -21,3 +29,27 @@ def test_password_channel_encryption():
     nonce, ct = channel.encrypt(password, b"top")
     pt = channel.decrypt(password, nonce, ct)
     assert pt == b"top"
+
+
+def test_decrypt_message_wrong_key():
+    """Decrypting with a non-matching private key should fail."""
+    priv_a, pub_a = generate_keypair()
+    priv_b, pub_b = generate_keypair()
+    enc = encrypt_message(b"data", pub_b)
+    with pytest.raises(Exception):
+        decrypt_message(enc, priv_a)
+
+
+def test_decrypt_message_tampered_ciphertext():
+    """Altering ciphertext should raise an authentication error."""
+    priv_a, pub_a = generate_keypair()
+    enc = encrypt_message(b"bits", pub_a)
+    # Flip one byte of the ciphertext to invalidate the tag
+    broken = enc.ciphertext_b64[:-2] + ("A" if enc.ciphertext_b64[-1] != "A" else "B")
+    tampered = enc.__class__(
+        ciphertext_b64=broken,
+        nonce_b64=enc.nonce_b64,
+        ephemeral_pub_b64=enc.ephemeral_pub_b64,
+    )
+    with pytest.raises(Exception):
+        decrypt_message(tampered, priv_a)


### PR DESCRIPTION
## Summary
- add tests covering crypto decryption failures
- add API failure tests for invalid message input
- verify missing file download returns 404
- document tests for clarity

## Testing
- `pytest tests/test_crypto.py tests/test_files.py::test_file_download_not_found tests/test_messages.py::test_send_invalid_base64_content tests/test_messages.py::test_send_invalid_signature -q`
- `pytest -q` *(fails: InvalidTag in AEAD, OperationalError in cleanup)*