### PR TITLE
Remove duplicate module docstring in logging tests

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,5 @@
 """Unit tests for the logging configuration."""
 
-"""Unit tests for the encrypted logging configuration."""
-
 import logging
 import os
 from base64 import b64encode, b64decode


### PR DESCRIPTION
## Summary
- clean up `tests/test_logging.py` by removing redundant top-level docstring

## Testing
- `pytest tests/test_logging.py`