### PR TITLE
Ensure thread-safe ratchet store access

### DIFF
--- a/tests/test_ratchet.py
+++ b/tests/test_ratchet.py
@@ -1,8 +1,14 @@
-"""Double ratchet unit tests."""
+"""Double ratchet unit tests.
 
-import base64
+These tests exercise the ratchet primitives in isolation and verify thread
+safe behaviour of the shared store used by the API.  Concurrency tests simulate
+multiple requests arriving in parallel to ensure that only one ratchet instance
+is created per conversation.
+"""
 
-from backend.ratchet import DoubleRatchet
+from concurrent.futures import ThreadPoolExecutor
+
+from backend.ratchet import DoubleRatchet, RatchetStore, get_ratchet
 
 
 def test_ratchet_rotation():
@@ -20,4 +26,41 @@ def test_ratchet_rotation():
     assert dr.root_key == second_key
     pt2 = dr.decrypt(ct2, nonce2)
     assert pt2 == b"bye"
+
+
+def test_store_get_thread_safe():
+    """RatchetStore.get should return a single instance under contention."""
+    store = RatchetStore(b"0" * 32)
+
+    def fetch() -> DoubleRatchet:
+        # Fetch the ratchet for a fixed conversation from multiple threads.
+        return store.get("alice", "bob")
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        rats = list(pool.map(lambda _: fetch(), range(10)))
+
+    first = rats[0]
+    # All threads must observe the same ratchet object.
+    assert all(r is first for r in rats)
+    # Only a single entry should exist in the internal store.
+    assert len(store._store) == 1
+
+
+def test_global_get_ratchet_thread_safe():
+    """get_ratchet should create one global store and ratchet concurrently."""
+
+    def fetch() -> DoubleRatchet:
+        # Access the global helper which internally initialises a shared store.
+        return get_ratchet("alice", "bob")
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        rats = list(pool.map(lambda _: fetch(), range(10)))
+
+    first = rats[0]
+    assert all(r is first for r in rats)
+    # The module-level store should only contain a single ratchet entry.
+    import backend.ratchet as ratchet_module
+
+    assert ratchet_module._store is not None
+    assert len(ratchet_module._store._store) == 1
 


### PR DESCRIPTION
## Summary
- Guard global `RatchetStore` initialization with a lock to prevent races
- Protect per-conversation ratchet lookups with double-checked locking
- Add tests simulating concurrent requests to verify thread safety

## Testing
- `pytest tests/test_ratchet.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb1d101288321b71e9c5b84236350