### PR TITLE
Require explicit CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ To run the application, follow these steps:
    * `AES_KEY` – base64 encoded 32 byte key used to encrypt persisted messages. A convenient way to generate one is `openssl rand -base64 32`.
    * Optional `DATABASE_URI` if you want to use a database other than the default SQLite file.
    * Optional `REDIS_URL` for persistent rate limiting and token blocklist storage.
-   * Optional `CORS_ORIGINS` to restrict allowed origins for both REST and
-     WebSocket connections.
+   * Required `CORS_ORIGINS` to enumerate origins permitted to access the REST
+     and WebSocket APIs. If unset, the backend rejects cross-origin requests to
+     prevent accidental exposure.
    * Optional cookie security settings: `JWT_COOKIE_SECURE`,
      `JWT_COOKIE_SAMESITE` and `JWT_COOKIE_CSRF_PROTECT`.
    * Optional push notification settings: `APNS_CERT`, `APNS_TOPIC`,


### PR DESCRIPTION
## Summary
- disable all cross-origin requests unless `CORS_ORIGINS` is set
- clarify in README that `CORS_ORIGINS` must be provided
- test that unlisted origins do not receive CORS headers

## Testing
- `pytest tests/test_headers.py`
- `pytest` *(fails: tests/test_auth.py::test_push_token_cleanup, tests/test_cleanup.py::test_cleanup_commits_once, tests/test_files.py::test_old_files_pruned, tests/test_files.py::test_first_attachment_requires_uploader)*