### PR TITLE
feat: retry push token registration on failure

### DIFF
--- a/frontend/src/utils/__tests__/push.test.js
+++ b/frontend/src/utils/__tests__/push.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for the Web Push registration helper.
+ *
+ * ``setupWebPush`` should post the push subscription to the backend and retry
+ * once when the backend responds with a non-2xx status. After two failures the
+ * error must be surfaced so callers are aware that push registration did not
+ * complete successfully.
+ */
+import api from '../../api';
+import { setupWebPush } from '../push';
+
+// Provide a minimal environment implementing the pieces of the Web Push API
+// used by ``setupWebPush``.
+beforeEach(() => {
+  // Mock permission prompt to grant notification access.
+  global.Notification = {
+    requestPermission: jest.fn().mockResolvedValue('granted'),
+  };
+
+  // Dummy subscription returned by the PushManager.
+  const fakeSub = { endpoint: 'test' };
+
+  const subscribe = jest.fn().mockResolvedValue(fakeSub);
+
+  // Service worker registration with a push manager capable of subscribing.
+  const registration = {
+    pushManager: { subscribe },
+  };
+
+  // Ensure navigator exists and expose the mocked service worker helpers.
+  global.navigator = global.navigator || {};
+  global.navigator.serviceWorker = {
+    getRegistration: jest.fn().mockResolvedValue(registration),
+    register: jest.fn().mockResolvedValue(registration),
+  };
+
+  // ``setupWebPush`` checks for the presence of ``PushManager`` on ``window``;
+  // augment the existing window object rather than replacing it so utilities
+  // like ``atob`` remain available.
+  global.window = global.window || {};
+  global.window.PushManager = function PushManager() {};
+});
+
+afterEach(() => {
+  // Reset spies and mocks so each test has a pristine environment.
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
+
+/**
+ * The happy path should send the subscription to the backend a single time.
+ */
+test('sends subscription to backend when registration succeeds', async () => {
+  const postMock = jest.spyOn(api, 'post').mockResolvedValue({ status: 201 });
+
+  await setupWebPush();
+
+  expect(postMock).toHaveBeenCalledTimes(1);
+});
+
+/**
+ * A failed attempt should be retried once and eventually succeed without
+ * logging an error.
+ */
+test('retries once on non-2xx response before succeeding', async () => {
+  const postMock = jest
+    .spyOn(api, 'post')
+    .mockRejectedValueOnce({ response: { status: 500 } })
+    .mockResolvedValueOnce({ status: 201 });
+
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  await setupWebPush();
+
+  expect(postMock).toHaveBeenCalledTimes(2);
+  expect(errSpy).not.toHaveBeenCalled();
+
+  errSpy.mockRestore();
+});
+
+/**
+ * When both attempts fail, the function should surface the error via
+ * ``console.error`` so callers can diagnose the issue.
+ */
+test('logs error after repeated failures', async () => {
+  jest
+    .spyOn(api, 'post')
+    .mockRejectedValue({ response: { status: 500 } });
+
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  await setupWebPush();
+
+  expect(api.post).toHaveBeenCalledTimes(2);
+  expect(errSpy).toHaveBeenCalled();
+
+  errSpy.mockRestore();
+});

--- a/frontend/src/utils/push.js
+++ b/frontend/src/utils/push.js
@@ -1,28 +1,85 @@
+/**
+ * Utilities for managing Web Push subscriptions.
+ *
+ * This module exposes helpers to register and unregister the browser with the
+ * backend's push service. It assumes the presence of Service Worker support
+ * and the Web Push API.
+ *
+ * Modification summary:
+ * - ``setupWebPush`` now validates the backend response when registering a
+ *   token. If the backend returns a non-2xx status or a network error occurs,
+ *   the function retries once before surfacing the failure via the catch
+ *   block. This helps diagnose push registration issues that would otherwise
+ *   be silently ignored.
+ */
+
 import api from '../api';
 import { urlB64ToUint8Array } from './encoding';
+
 /**
  * Attempt to register the browser for push notifications and send the
  * resulting subscription to the backend. When unsupported or denied, the
  * function exits silently.
  */
-
 export async function setupWebPush() {
+  // Abort early in environments that lack Service Worker or Push API support.
   if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
   if (typeof Notification === 'undefined' || !('PushManager' in window)) return;
+
   try {
     const perm = await Notification.requestPermission();
-    if (perm !== 'granted') return;
+    if (perm !== 'granted') return; // User declined notifications.
+
+    // Either retrieve an existing worker registration or create one so we can
+    // obtain a push subscription from it.
     let reg = await navigator.serviceWorker.getRegistration();
     if (!reg) {
       reg = await navigator.serviceWorker.register('/sw.js');
     }
+
+    // Subscribe the client to push notifications using the VAPID public key
+    // provided at build time. ``userVisibleOnly`` ensures each push results in
+    // a notification, satisfying browser requirements.
     const key = process.env.REACT_APP_VAPID_PUBLIC_KEY || '';
     const sub = await reg.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: urlB64ToUint8Array(key),
     });
-    await api.post('/api/push-token', { token: JSON.stringify(sub), platform: 'web' });
+
+    const payload = { token: JSON.stringify(sub), platform: 'web' };
+
+    // Attempt to persist the subscription with the backend. We retry once on a
+    // network failure or non-2xx HTTP status so transient issues do not
+    // permanently disable push notifications.
+    let attempt = 0;
+    let lastError;
+    while (attempt < 2) {
+      try {
+        // ``api.post`` resolves with the full Axios response object. We inspect
+        // the HTTP status to ensure the backend accepted the subscription.
+        // Axios ordinarily rejects non-2xx statuses, but explicitly checking
+        // makes the intent clear and protects against custom ``validateStatus``
+        // configurations.
+        const res = await api.post('/api/push-token', payload);
+        if (res.status >= 200 && res.status < 300) {
+          return; // Successfully registered the push token.
+        }
+
+        // Treat an unexpected status as an error to trigger a retry.
+        lastError = new Error(`Unexpected status code ${res.status}`);
+      } catch (err) {
+        // Capture the error so it can be surfaced if all retries fail.
+        lastError = err;
+      }
+      attempt += 1;
+    }
+
+    // If both attempts failed, surface the error via the catch block below to
+    // aid troubleshooting.
+    throw lastError;
   } catch (e) {
+    // Logging the error is important for visibility because callers typically
+    // fire-and-forget this function during application startup.
     console.error('Failed to setup push', e);
   }
 }


### PR DESCRIPTION
## Summary
- validate backend response when registering web push subscriptions
- add tests covering success and retry/failure paths

## Testing
- `npm test -- src/utils/__tests__/push.test.js`
- `npm test` *(fails: Cache secret not initialized in message cache tests)*
- `npm run lint` *(fails: numerous lint errors across existing files)*