### PR TITLE
feat: isolate scheduler from web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ To run the application, follow these steps:
 3. Install backend dependencies with `pip install -r requirements.txt`.
 4. Install frontend dependencies with `npm install` inside the `frontend` directory.
 5. Start the backend with `python backend/app.py` and the frontend with `npm start`.
-6. Open a browser and navigate to the frontend's URL to use the application.
+6. Launch the background scheduler in a **separate process** so cleanup tasks run
+   exactly once. See [docs/scheduler.md](docs/scheduler.md) for detailed
+   instructions. A quick start looks like:
+
+   ```bash
+   RUN_SCHEDULER=1 python -m backend.scheduler_service
+   ```
+
+7. Open a browser and navigate to the frontend's URL to use the application.
 7. After registering a user, persist the returned `encrypted_private_key`, `salt` and `nonce`. The React client stores these values in IndexedDB so the private key can be decrypted on login. The iOS client saves the same values securely in the Keychain.
 
 ### Enabling Secure Cookies

--- a/backend/scheduler_service.py
+++ b/backend/scheduler_service.py
@@ -1,0 +1,29 @@
+"""Standalone entry point for running background maintenance jobs.
+
+This module ensures the APScheduler instance defined in :mod:`backend.app` runs
+in a dedicated process. Use it for deployments where the web application and
+scheduled tasks operate separately, such as containerized environments or
+systemd services.
+
+Example (Docker):
+    RUN_SCHEDULER=1 python -m backend.scheduler_service
+
+Example (systemd service snippet):
+    [Service]
+    Environment=RUN_SCHEDULER=1
+    ExecStart=/usr/bin/python -m backend.scheduler_service
+"""
+
+# Importing ``start_scheduler`` sets up the Flask application and job
+# definitions. The function performs a safety check to ensure the scheduler
+# only runs when ``RUN_SCHEDULER=1``.
+from .app import start_scheduler
+
+
+def main() -> None:
+    """Entry point that starts the background scheduler."""
+    start_scheduler()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,67 @@
+# Background Scheduler
+
+The backend uses [APScheduler](https://apscheduler.readthedocs.io/) to perform
+periodic maintenance tasks such as removing expired messages and pruning stale
+push notification tokens. These jobs **must** run in exactly one process to
+avoid duplicated work.
+
+## Running the scheduler
+
+1. Build or configure a Python environment with the backend's dependencies.
+2. Set the environment variable `RUN_SCHEDULER=1` to acknowledge that this
+   process is responsible for running the scheduler.
+3. Execute the dedicated entry point:
+
+   ```bash
+   RUN_SCHEDULER=1 python -m backend.scheduler_service
+   ```
+
+   The command imports the Flask application, registers all scheduled jobs and
+   starts the scheduler. It exits with an error if `RUN_SCHEDULER` is missing to
+   prevent accidental startup.
+
+## Deployment options
+
+### Separate container
+
+When deploying with containers, create a small service that only runs the
+scheduler:
+
+```yaml
+dependencies:
+  backend:
+    image: privatelinedocker/backend
+  scheduler:
+    image: privatelinedocker/backend
+    command: python -m backend.scheduler_service
+    environment:
+      RUN_SCHEDULER: "1"
+```
+
+### systemd service
+
+For bare-metal deployments, a systemd unit keeps the scheduler alive:
+
+```ini
+[Unit]
+Description=PrivateLine background scheduler
+After=network.target
+
+[Service]
+Type=simple
+Environment=RUN_SCHEDULER=1
+ExecStart=/usr/bin/python -m backend.scheduler_service
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the service with `systemctl enable --now privatelinescheduler`.
+
+## Notes
+
+The web application (`python backend/app.py`) does **not** start the scheduler.
+Running multiple scheduler instances simultaneously can result in redundant
+cleanup operations or race conditions. Always ensure that only one process sets
+`RUN_SCHEDULER=1`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,9 @@ import os
 import base64
 import io
 
-# Flag that ensures the Flask app does not start background schedulers when
-# imported for the test suite.
+# Flag indicating that tests are running. The application no longer starts the
+# background scheduler automatically, but other components may still consult this
+# variable to tweak behaviour during tests.
 os.environ.setdefault("TESTING", "1")
 import pytest
 from base64 import b64decode

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,41 @@
+"""Tests covering the standalone background scheduler."""
+
+import pytest
+
+from backend.app import scheduler, start_scheduler
+
+
+def test_start_scheduler_requires_flag(monkeypatch):
+    """Ensure the scheduler refuses to start without RUN_SCHEDULER=1."""
+    # Remove any preset flag and stub out the actual start method so tests do
+    # not spawn background threads.
+    monkeypatch.delenv("RUN_SCHEDULER", raising=False)
+    called = {"start": False}
+
+    def fake_start():
+        called["start"] = True
+
+    monkeypatch.setattr(scheduler, "start", fake_start)
+
+    with pytest.raises(RuntimeError):
+        start_scheduler()
+
+    # ``start`` must not have been invoked due to the missing flag.
+    assert called["start"] is False
+
+
+def test_start_scheduler_runs_with_flag(monkeypatch):
+    """Verify the scheduler starts when RUN_SCHEDULER=1 is provided."""
+    monkeypatch.setenv("RUN_SCHEDULER", "1")
+    started = {"flag": False}
+
+    def fake_start():
+        started["flag"] = True
+
+    monkeypatch.setattr(scheduler, "start", fake_start)
+    # Avoid registering real ``atexit`` handlers during the test suite.
+    monkeypatch.setattr("backend.app.atexit.register", lambda func: None)
+
+    start_scheduler()
+
+    assert started["flag"] is True


### PR DESCRIPTION
## Summary
- add explicit `start_scheduler` gate and standalone scheduler entry point
- document running maintenance scheduler as a separate process
- cover scheduler start logic with unit tests

## Testing
- `pytest` *(fails: sqlite3.OperationalError: no such table, InvalidRequestError)*

------
https://chatgpt.com/codex/tasks/task_e_68a50541ddb8832183e2b5142700737e