### PR TITLE
Add certificate refresh script and pinning warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ instance/
 # Android Gradle wrapper
 android/gradle/wrapper/gradle-wrapper.jar
 
+# iOS TLS certificate is generated at build time
+ios/PrivateLine/Resources/server.cer
+

--- a/ios/PrivateLine/ContentView.swift
+++ b/ios/PrivateLine/ContentView.swift
@@ -1,3 +1,9 @@
+/*
+ * ContentView.swift - SwiftUI entry point for the iOS client.
+ * Displays login or chat screens and now surfaces certificate pinning warnings
+ * if the bundled ``server.cer`` does not match the server. This guides users to
+ * refresh their app when the backend certificate changes.
+ */
 import SwiftUI
 
 /// Root view that displays either the login screen or chat depending on auth state.
@@ -35,6 +41,15 @@ struct ContentView: View {
         }
         // Respect the user's dark mode preference
         .preferredColorScheme(isDarkMode ? .dark : .light)
+        // Warn the user when certificate pinning fails so they know to update.
+        .alert(
+            "Connection Untrusted",
+            isPresented: $api.showCertificateWarning
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("The server's certificate doesn't match the one bundled with the app. Please update the app or contact support to refresh the pinned certificate.")
+        }
     }
 }
 

--- a/ios/PrivateLineTests/APIServicesTests.swift
+++ b/ios/PrivateLineTests/APIServicesTests.swift
@@ -150,6 +150,40 @@ final class APIServicesTests: XCTestCase {
         XCTAssertEqual(disposition, .useCredential)
     }
 
+    /**
+     * Pinning failures should trigger ``showCertificateWarning`` so the UI can
+     * inform the user that the app's bundled certificate is outdated.
+     */
+    func testPinningMismatchSetsWarning() throws {
+        // Write the expected pinned certificate to the bundle location.
+        let pinnedBase64 = "MIIDCTCCAfGgAwIBAgIUQ4ts0UuXVBAe4Ao+YQYGUlGetikwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJVGVzdCBDZXJ0MB4XDTI1MDYwODAyMzYzNFoXDTI1MDYwOTAyMzYzNFowFDESMBAGA1UEAwwJVGVzdCBDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnN3zYWtPN7AHCv4pj8XU7frxqV62QsXV/2WY165aCusP/d/r7zcK6LHr5AAm237cruxdiq72+AHsGuMMFY34BfQIHBujP3mfRU7lwuafW+jRPdBgsvG/GhVqAqZd4nx1a07kytDOuaw0TTZVIcSDg12uiNRto/QTP1ryXxT9o4tmmyQKcficRzC5hIj5QkNIGb6gFKhkZoirU8FK7ew6S+UCjjzrOvo7V5owGvqxkkZ4DcVs4TI1FILTXET7mQdN7FZCIzEQbKDsghSfOa2CBUBJHLzgFKwBYyFc2QEZBEiY3pWxR50xCo3XG56J/8Yw3mWDExQCinFY+lEu3o1Q3wIDAQABo1MwUTAdBgNVHQ4EFgQU9RUwc5f8zi+HNTnr3f14RQ9wWbIwHwYDVR0jBBgwFoAU9RUwc5f8zi+HNTnr3f14RQ9wWbIwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAdqa0cv7N5ZtS5OnVgG/8LRNyAcBqFNTt871kRjq84hDaHSE1QIrJXXVor1fqel+0oz75IEFBD9JJbOrP+MI8Ubl3kNEg24UK7XKesfNYv9XQUw1JtCxbl0opOWGTkvi+o/X3LQFuopvV/xy1Zh5Q2BMTkG67fS2eXNPXpuBbdoe3uMlmTVKqQYGTNwk0vDvkWsgUM1zJz1wG64b9dk3HEkn/+6incanPLWS+isFEFE+OqtJ2tpY+VOlprHLAmBkUWp+A57+l+9csvKW9R29GvJzTprrjBfQ9iFP+COzE4jFfxzb8xRO6LC/9bejXN3YX5TJDjMRescIpdrybL+br/w=="
+        let pinnedURL = URL(fileURLWithPath: Bundle.main.bundlePath).appendingPathComponent("server.cer")
+        try? Data(base64Encoded: pinnedBase64)!.write(to: pinnedURL)
+
+        // Second certificate differs from the pinned one to trigger mismatch.
+        let mismatchedBase64 = "MIIDCTCCAfGgAwIBAgIUfr8HrXSxktDFz50uCCyOmqM9CmEwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UEAwwJVGVzdCBDZXJ0MB4XDTI1MDgyMTIyMTkzOVoXDTI2MDgyMTIyMTkzOVowFDESMBAGA1UEAwwJVGVzdCBDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6z4pCsIue5vGk5IM9XZYEjm464iaQwchtaIjH88YSQALzQ4OpQeJTpTq6we59rKcOXfGslU1ovlXL5+mquJ2wY/50GWxnpqGdWeipTA3VTp94ANm7MkhkWLZbbO+oYh+Reumu8m6hcAW4sF85PS7vlCUIh2aMRncfb3wTz9ejsFSATrdtSSBFHFzd4/C2XYEpWwkmAKPjhmQVpUbq4M7dEmFtCaAAGheGosIiafpwd+pVuARUkzgbX0ZHmVj5+y/K9u6HIRs/8x3hDmH/6fL9s/Yzty+H2Gi6nTWETvN3KfBOQwioajArqextjnjHCTkxKwq6MH8sxBXCETyT64j3QIDAQABo1MwUTAdBgNVHQ4EFgQUUGmJFVCrged00o3q3xSOlv7H+XgwHwYDVR0jBBgwFoAUUGmJFVCrged00o3q3xSOlv7H+XgwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAjOHlZMozBGGdcshAAiMZYpT05z/Ik5YgpRFRlayYHJIyMAAFIWPewnvmz8vDbZYUKl6FUjw5Ph2keah/y7dRQYGPItl7FAEum4HfmOeDH8debEvJZCM+69bqGv9e/cSKM92PojodnHqG91GW83ShWDS/CHAz2pR+2YeT+J2HTzhFhK4u8vutgKt854ErhspjiZKl0xVDLc6W3rYMQO/RXfd0FIXh72O8/NlV214WgOlrii5lBVOFxjm5D6/LkvYZOQnZBLFsWJ0DrBJckuD9pO7nRpzK2mKebCp6n5GDrs8bQzJjt1ItH6B5Fz5DrQ9FAjgeDxpkWBHgKQUC2s5ZMA=="
+
+        let service = APIService()
+        let mirror = Mirror(reflecting: service)
+        guard let session = mirror.descendant("session") as? URLSession,
+              let delegate = session.delegate else {
+            return XCTFail("Missing delegate")
+        }
+
+        let mismatchedData = Data(base64Encoded: mismatchedBase64)!
+        let cert = SecCertificateCreateWithData(nil, mismatchedData as CFData)!
+        var trust: SecTrust?
+        SecTrustCreateWithCertificates(cert, SecPolicyCreateSSL(true, nil), &trust)
+        let challenge = URLAuthenticationChallenge(trust: trust!, proposedCredential: nil, previousFailureCount: 0, failureResponse: nil, error: nil, sender: nil)
+        let exp = expectation(description: "challenge")
+        delegate.urlSession?(session, didReceive: challenge) { _ , _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertTrue(service.showCertificateWarning)
+    }
+
     // MARK: - Helpers
     private func pemString(for data: Data, header: String, footer: String) -> String {
         let b64 = data.base64EncodedString(options: [.lineLength64Characters])

--- a/ios/README.md
+++ b/ios/README.md
@@ -79,3 +79,26 @@ focuses on a different component:
 Running these tests regularly helps ensure the iOS client continues to work
 correctly as new features are added.
 
+## Refreshing the Pinned TLS Certificate
+
+The app pins the backend's TLS certificate via `server.cer` located under
+`Resources/`. Because the file contains environment-specific material it is
+*not* tracked by Git. Builds will fail to connect if the bundled certificate is
+missing or outdated, so run the helper script whenever the backend rotates its
+certificate.
+
+```bash
+./scripts/update_server_cert.sh api.example.com
+```
+
+The script downloads the leaf certificate from the given host, writes it to
+`ios/PrivateLine/Resources/server.cer`, and prints the SHA-256 public-key
+fingerprint. Replace Android's `CERTIFICATE_SHA256` value with the printed
+fingerprint to keep both platforms aligned.
+
+Integrate this script into CI so new certificates are fetched automatically
+before building the mobile apps. At runtime `APIService` logs a warning when the
+embedded certificate is within 30 days of expiring, and `ContentView` surfaces a
+user-facing alert if pinning validation fails. In both cases rerun the script to
+refresh the certificate bundle.
+

--- a/scripts/update_server_cert.sh
+++ b/scripts/update_server_cert.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# update_server_cert.sh - Retrieve latest TLS certificate and update client pins.
+#
+# This helper automates TLS certificate rotation for both mobile platforms.
+# It downloads the server's leaf certificate, stores it as
+# `ios/PrivateLine/Resources/server.cer` for iOS certificate pinning, and prints
+# the SHA-256 public-key fingerprint used by Android's certificate pinner. The
+# generated `server.cer` file is gitignored; run this script whenever the backend
+# certificate changes so new builds include the correct pin.
+#
+# Usage:
+#   scripts/update_server_cert.sh <host> [port]
+#
+# Example:
+#   scripts/update_server_cert.sh api.example.com 8443
+#
+# Arguments:
+#   <host>  Hostname of the backend server.
+#   [port]  Optional TLS port, defaults to 443.
+#
+# Requirements:
+#   - OpenSSL must be installed and in the PATH.
+#   - Run from the repository root so relative paths resolve correctly.
+
+set -euo pipefail
+
+HOST=${1:-}
+PORT=${2:-443}
+
+if [[ -z "$HOST" ]]; then
+  echo "Usage: $0 <host> [port]" >&2
+  exit 1
+fi
+
+TMP_CERT=$(mktemp)
+
+# Retrieve the server's certificate in DER format. ``openssl s_client`` performs
+# the TLS handshake and outputs the certificate chain, which we then convert to
+# raw DER bytes with ``openssl x509``.
+echo | openssl s_client -servername "$HOST" -connect "$HOST:$PORT" -showcerts 2>/dev/null \
+  | openssl x509 -outform der > "$TMP_CERT"
+
+# Place the DER certificate where the iOS project expects it. The path is
+# gitignored so developers and CI pipelines must run this script before building
+# when the backend certificate changes.
+cp "$TMP_CERT" ios/PrivateLine/Resources/server.cer
+
+# Emit fingerprint used by Android's certificate pinner. This SHA-256 digest of
+# the public key is inserted into ``CERTIFICATE_SHA256`` in the Android project.
+echo "Android pin SHA-256:"
+openssl x509 -in "$TMP_CERT" -noout -pubkey \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -binary \
+  | base64
+
+# Remove the temporary certificate file to avoid leaving sensitive material on
+# disk.
+rm -f "$TMP_CERT"


### PR DESCRIPTION
## Summary
- prevent committing TLS certificate by gitignore and ensure script is used to fetch new one
- expand update_server_cert.sh with usage examples and step-by-step explanations
- enrich iOS README with certificate refresh workflow and guidance on runtime warnings

## Testing
- `bash -n scripts/update_server_cert.sh`
- `swift test` *(fails: no such module 'SwiftUI')*