### PR TITLE
Encrypt cached iOS messages and add tests

### DIFF
--- a/ios/PrivateLineTests/MessageStoreTests.swift
+++ b/ios/PrivateLineTests/MessageStoreTests.swift
@@ -1,33 +1,71 @@
 import XCTest
 @testable import PrivateLine
 
-/// Verifies the lightweight disk cache used by the iOS client.
+/*
+ * MessageStoreTests.swift
+ * ----------------------
+ * Unit tests validating the message caching layer. The tests focus on
+ * verifying that messages are encrypted on disk and that the persistence API
+ * performs a lossless round-trip when the correct key is available.
+ */
 
+// Extend ``Message`` with ``Equatable`` so arrays can be compared in tests.
 extension Message: Equatable {}
 
-/// Ensures messages persist to disk and can be reloaded accurately.
+/// Test suite exercising the ``MessageStore`` persistence logic.
 final class MessageStoreTests: XCTestCase {
+    /// Location of the encrypted cache file used for test fixtures.
     let fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         .appendingPathComponent("messages.json")
 
     override func setUpWithError() throws {
-        try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        // Ensure a clean directory exists for each test run.
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try? FileManager.default.removeItem(at: fileURL)
     }
 
     override func tearDownWithError() throws {
+        // Clean up the cache file after each test so cases remain isolated.
         try? FileManager.default.removeItem(at: fileURL)
     }
 
+    /// Persist messages then verify they round-trip correctly through the
+    /// encryption and decoding pipeline.
     func testSaveLoadRoundTrip() throws {
-        // Persist messages then verify they round-trip correctly
         let messages = [
             Message(id: 1, content: "Hi", file_id: nil, read: true),
             Message(id: 2, content: "Bye", file_id: nil, read: false)
         ]
+
         MessageStore.save(messages)
-        sleep(1)
+        sleep(1) // Allow background save to complete before reading.
         let loaded = MessageStore.load()
         XCTAssertEqual(loaded, messages)
+    }
+
+    /// Ensure that the encrypted file cannot be decoded without first
+    /// decrypting using ``CryptoManager``.
+    func testDataUnreadableWithoutDecryption() throws {
+        let messages = [
+            Message(id: 1, content: "Secret", file_id: nil, read: true)
+        ]
+
+        // Save the message and wait for the asynchronous write to finish.
+        MessageStore.save(messages)
+        sleep(1)
+
+        let raw = try Data(contentsOf: fileURL)
+
+        // Attempting to decode the encrypted blob directly should fail because
+        // the bytes are not valid JSON without decryption.
+        XCTAssertThrowsError(try JSONDecoder().decode([Message].self, from: raw))
+
+        // Additionally ensure that obvious plaintext is absent to highlight
+        // that the data is indeed encrypted.
+        let rawString = String(data: raw, encoding: .utf8)
+        XCTAssertFalse(rawString?.contains("Secret") ?? false)
     }
 }


### PR DESCRIPTION
## Summary
- Encrypt messages before persisting cache and decrypt on load
- Protect cached file with complete file protection
- Add tests covering encryption and round-trip behavior

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*