### PR TITLE
feat: add session lock with biometric re-auth

### DIFF
--- a/ios/PrivateLine/PrivacyShield.swift
+++ b/ios/PrivateLine/PrivacyShield.swift
@@ -1,40 +1,119 @@
+// PrivacyShield.swift
+//
+// Provides an overlay that hides sensitive content when the application is not
+// active or when screen recording is detected. The session lock now requires
+// biometric or passcode authentication via ``LocalAuthentication`` before the
+// overlay is dismissed, preventing unauthorized access when returning to the
+// app.
 import SwiftUI
 import Combine
+import LocalAuthentication
 
 /// Monitors application state and screen capture status to hide sensitive content.
 ///
 /// When `obscured` becomes true a dark overlay should be displayed so the app
 /// contents are not visible in the App Switcher or during screen recording.
+/// Tracks application lifecycle events to protect sensitive content and enforce
+/// a session lock when the app returns from the background.
+///
+/// The shield hides the UI whenever the app becomes inactive or when screen
+/// capture is detected. Upon re-entering the foreground the user must
+/// re-authenticate via biometrics or passcode before the overlay disappears.
 final class PrivacyShield: ObservableObject {
     /// Indicates that the UI should be hidden behind an overlay.
     @Published var obscured: Bool = false
+    /// Set when the most recent authentication attempt failed so callers can
+    /// present a helpful error message.
+    @Published var authFailed: Bool = false
 
+    /// Factory providing ``LAContext`` instances. Exposed for unit testing so
+    /// tests can inject mocked contexts that simulate success or failure.
+    private let contextProvider: () -> LAContext
+    /// Tracks Combine subscriptions for lifecycle notifications.
     private var cancellables: Set<AnyCancellable> = []
+    /// True when the app moved to the background and the user must
+    /// authenticate before content becomes visible again.
+    private var needsAuthentication = false
 
-    init() {
-        // Hide content whenever the app resigns active or enters background
+    /// Create a new ``PrivacyShield``.
+    /// - Parameter contextProvider: Closure returning a fresh ``LAContext``. If
+    ///   omitted a default instance is created. Tests provide custom closures to
+    ///   control authentication outcomes.
+    init(contextProvider: @escaping () -> LAContext = { LAContext() }) {
+        self.contextProvider = contextProvider
+
+        // Hide content whenever the app resigns active or enters background.
         NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
             .merge(with: NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification))
-            .sink { [weak self] _ in self?.obscured = true }
+            .sink { [weak self] _ in
+                // Mark that re-authentication is required and obscure UI.
+                self?.needsAuthentication = true
+                self?.obscured = true
+            }
             .store(in: &cancellables)
 
-        // Reevaluate visibility when returning to the foreground
+        // When returning to the foreground request authentication before
+        // clearing the overlay.
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .sink { [weak self] _ in self?.updateCaptureState() }
+            .sink { [weak self] _ in self?.authenticateIfNeeded() }
             .store(in: &cancellables)
 
-        // Update whenever screen capture starts or stops
+        // Update whenever screen capture starts or stops.
         NotificationCenter.default.publisher(for: UIScreen.capturedDidChangeNotification)
             .sink { [weak self] _ in self?.updateCaptureState() }
             .store(in: &cancellables)
 
-        // Initial state based on current capture flag
+        // Initial state based on current capture flag.
         updateCaptureState()
     }
 
-    /// Refresh the `obscured` property using the current screen capture status.
+    /// Attempt to unlock the session if required. On success the overlay is
+    /// removed; on failure the UI remains obscured and an error flag is raised.
+    func authenticateIfNeeded() {
+        guard needsAuthentication else {
+            updateCaptureState()
+            return
+        }
+
+        let context = contextProvider()
+        // Reason displayed by the system authentication dialog.
+        let reason = "Authenticate to unlock PrivateLine"
+        var error: NSError?
+        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { [weak self] success, _ in
+                DispatchQueue.main.async {
+                    if success {
+                        // Authentication succeeded: allow content to become visible.
+                        self?.needsAuthentication = false
+                        self?.authFailed = false
+                        self?.updateCaptureState()
+                    } else {
+                        // Failure keeps the overlay visible until user retries.
+                        self?.authFailed = true
+                        self?.obscured = true
+                    }
+                }
+            }
+        } else {
+            // Device cannot evaluate policy; treat as failure.
+            authFailed = true
+            obscured = true
+        }
+    }
+
+    /// Allow UI layer to retry authentication after a failure.
+    func retryAuthentication() {
+        authenticateIfNeeded()
+    }
+
+    /// Refresh the `obscured` property using the current screen capture status
+    /// while respecting the session lock requirement.
     private func updateCaptureState() {
-        obscured = UIScreen.main.isCaptured || UIApplication.shared.applicationState != .active
+        if needsAuthentication {
+            obscured = true
+        } else {
+            obscured = UIScreen.main.isCaptured || UIApplication.shared.applicationState != .active
+        }
     }
 }
 

--- a/ios/PrivateLine/PrivateLineApp.swift
+++ b/ios/PrivateLine/PrivateLineApp.swift
@@ -1,3 +1,10 @@
+// Application entry point for the PrivateLine iOS client.
+//
+// Modifications:
+// - Integrated re-authentication flow with ``PrivacyShield`` by presenting
+//   an alert when biometric or passcode verification fails.
+// - Alert allows users to retry authentication, keeping the UI obscured until
+//   credentials are confirmed.
 import SwiftUI
 import UIKit
 
@@ -32,6 +39,23 @@ struct PrivateLineApp: App {
         WindowGroup {
             ContentView()
                 .privacyOverlay(shield: shield)
+                // Present a friendly message when the biometric prompt fails.
+                .alert(
+                    "Authentication Failed",
+                    isPresented: Binding(
+                        get: { shield.authFailed },
+                        set: { shield.authFailed = $0 }
+                    ),
+                    actions: {
+                        Button("Retry") {
+                            // Allow the user to attempt authentication again.
+                            shield.retryAuthentication()
+                        }
+                    },
+                    message: {
+                        Text("Unable to verify your identity. Please try again.")
+                    }
+                )
         }
     }
 }

--- a/ios/PrivateLineTests/PrivacyShieldTests.swift
+++ b/ios/PrivateLineTests/PrivacyShieldTests.swift
@@ -1,0 +1,78 @@
+// Unit tests exercising the session lock managed by ``PrivacyShield``.
+//
+// These tests validate that the UI overlay remains until the user successfully
+// authenticates with biometrics or passcode. ``LAContext`` is mocked to simulate
+// both success and failure without invoking actual device security mechanisms.
+//
+// Design decisions:
+// - The tests post lifecycle notifications directly to mimic the app moving to
+//   the background and back to the foreground.
+// - ``MockContext`` subclasses ``LAContext`` so `PrivacyShield` can be tested in
+//   isolation without hitting system APIs.
+
+import XCTest
+import LocalAuthentication
+import UIKit
+@testable import PrivateLine
+
+/// Mock ``LAContext`` allowing tests to dictate authentication outcomes.
+final class MockContext: LAContext {
+    /// Controls the value returned by ``canEvaluatePolicy``.
+    var canEvaluate: Bool = true
+    /// Determines whether ``evaluatePolicy`` invokes its reply block with success.
+    var evaluateSucceeds: Bool = true
+
+    override func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
+        return canEvaluate
+    }
+
+    override func evaluatePolicy(_ policy: LAPolicy, localizedReason: String, reply: @escaping (Bool, Error?) -> Void) {
+        // Call the reply handler synchronously for deterministic tests.
+        reply(evaluateSucceeds, nil)
+    }
+}
+
+/// Verifies that successful authentication clears the privacy overlay and resets
+/// the failure flag.
+final class PrivacyShieldTests: XCTestCase {
+    /// Helper to allow asynchronous callbacks to complete.
+    private func waitForAuthentication() {
+        // Run the main loop briefly so DispatchQueue callbacks execute.
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+    }
+
+    /// Authentication success should reveal the UI and keep ``authFailed`` false.
+    func testAuthenticationSuccessClearsOverlay() {
+        let context = MockContext()
+        context.evaluateSucceeds = true
+        let shield = PrivacyShield(contextProvider: { context })
+
+        // Simulate app moving to background.
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        XCTAssertTrue(shield.obscured)
+
+        // Returning to foreground triggers authentication.
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        waitForAuthentication()
+
+        // Overlay should disappear and no error should be flagged.
+        XCTAssertFalse(shield.obscured)
+        XCTAssertFalse(shield.authFailed)
+    }
+
+    /// Failed authentication should keep the overlay visible and flag an error.
+    func testAuthenticationFailureKeepsOverlay() {
+        let context = MockContext()
+        context.evaluateSucceeds = false
+        let shield = PrivacyShield(contextProvider: { context })
+
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        XCTAssertTrue(shield.obscured)
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        waitForAuthentication()
+
+        XCTAssertTrue(shield.obscured)
+        XCTAssertTrue(shield.authFailed)
+    }
+}


### PR DESCRIPTION
## Summary
- add LocalAuthentication-based session lock in PrivacyShield
- surface retryable auth failure alert in PrivateLineApp
- test session lock success and failure with mocked LAContext

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a8ee9c835c8321b7aa406aae37a3c1