### PR TITLE
Define App Transport Security policy for iOS client

### DIFF
--- a/ios/PrivateLine/Resources/Config/Info.plist
+++ b/ios/PrivateLine/Resources/Config/Info.plist
@@ -1,10 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    Configuration file for the PrivateLine iOS client.
+    Defines backend network endpoints and transport security policies.
+    Developers may adjust these values for different environments.
+-->
 <plist version="1.0">
 <dict>
+    <!-- Base URL for API requests issued by the SwiftUI client. -->
     <key>BackendBaseURL</key>
     <string>http://localhost:5000/api</string>
+
+    <!-- WebSocket endpoint used for real-time messaging. -->
     <key>WebSocketURL</key>
     <string>ws://localhost:5000/socket.io/?transport=websocket</string>
+
+    <!--
+        App Transport Security (ATS) enforces secure network connections.
+        We prohibit arbitrary insecure HTTP loads while allowing a
+        localhost exception to facilitate development against a local
+        backend server.
+    -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <!-- Explicitly disallow insecure requests to arbitrary domains. -->
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+
+        <!-- Domain-specific overrides for development convenience. -->
+        <key>NSExceptionDomains</key>
+        <dict>
+            <!-- Permit HTTP traffic to a locally running backend server. -->
+            <key>localhost</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/ios/README.md
+++ b/ios/README.md
@@ -11,6 +11,18 @@ variables.
    `WebSocketURL` if your backend does not run on `localhost`.
 3. Build and run the app in the iOS simulator.
 
+## App Transport Security
+
+The client follows Apple's [App Transport Security](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) (ATS) policy to ensure all network requests use TLS.
+A default exception for `localhost` is provided so the simulator can communicate with a local development backend.
+
+To add a temporary exception for another host:
+
+1. Edit `Resources/Config/Info.plist`.
+2. Under `NSAppTransportSecurity -> NSExceptionDomains`, add the host's `<key>`.
+3. Inside that dictionary set `<key>NSExceptionAllowsInsecureHTTPLoads</key>` to `<true/>`.
+4. Remove the override before committing production code to maintain transport security.
+
 After launching the app you will be greeted with a short onboarding flow describing encryption and privacy. You can then create an account or log in. Messages are loaded from local storage first and updated in real time via WebSockets.
 
 The main interface uses a tab bar with sections for Chats and Settings. Credentials are protected with biometrics and you may revoke all server sessions from the Settings tab.


### PR DESCRIPTION
## Summary
- configure App Transport Security in iOS Info.plist
- block arbitrary HTTP loads while whitelisting localhost for development
- document how to add temporary ATS exceptions in ios README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acb5a9d6b08321ac1ceb259e22da89