### PR TITLE
Enforce secure backend URLs

### DIFF
--- a/ios/PrivateLine/ContentView.swift
+++ b/ios/PrivateLine/ContentView.swift
@@ -9,8 +9,10 @@ import SwiftUI
 
 /// Root view that displays either the login screen or chat depending on auth state.
 struct ContentView: View {
-    /// Shared API service used across the app.
-    @StateObject private var api = APIService()
+    /// Shared API service used across the app. ``try!`` is safe because a
+    /// missing or insecure URL indicates a developer configuration error and
+    /// should abort early during development.
+    @StateObject private var api = try! APIService()
     /// Remembers whether the onboarding screen has been displayed.
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     /// Persisted color scheme preference.

--- a/ios/PrivateLine/Resources/Config/Info.plist
+++ b/ios/PrivateLine/Resources/Config/Info.plist
@@ -9,11 +9,11 @@
 <dict>
     <!-- Base URL for API requests issued by the SwiftUI client. -->
     <key>BackendBaseURL</key>
-    <string>http://localhost:5000/api</string>
+    <string>https://localhost:5000/api</string>
 
     <!-- WebSocket endpoint used for real-time messaging. -->
     <key>WebSocketURL</key>
-    <string>ws://localhost:5000/socket.io/?transport=websocket</string>
+    <string>wss://localhost:5000/socket.io/?transport=websocket</string>
 
     <!--
         App Transport Security (ATS) enforces secure network connections.


### PR DESCRIPTION
## Summary
- require https and wss schemes in configuration and networking services
- allow injecting sockets for testing
- validate URL schemes in unit tests

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68acbdd244d88321a2c9c1067328f1a3