### PR TITLE
Pin push registration token with certificate and handle failures

### DIFF
--- a/ios/PrivateLine/APIService.swift
+++ b/ios/PrivateLine/APIService.swift
@@ -27,6 +27,8 @@
  * - Introduced exponential backoff for failed login attempts, delaying each
  *   subsequent attempt to slow brute-force guessing. The delay resets upon
  *   successful authentication.
+ * - Exposed the certificate pinning delegate for reuse by components such as
+ *   ``NotificationManager`` to ensure consistent TLS validation.
  */
 import Foundation
 import Crypto
@@ -718,7 +720,10 @@ class APIService: ObservableObject {
     /// SHA-256 hash of each certificate's SubjectPublicKeyInfo against a set of
     /// precomputed fingerprints. Storing multiple fingerprints allows the app to
     /// accept both the current and the next certificate during rotations.
-    private class PinningDelegate: NSObject, URLSessionDelegate {
+    /// Delegate enforcing server certificate pinning for all API calls. Exposed
+    /// so other modules (e.g. ``NotificationManager``) can reuse the same trust
+    /// evaluation logic and avoid duplicating pinning code.
+    final class PinningDelegate: NSObject, URLSessionDelegate {
         /// Pinned SPKI fingerprints loaded from ``server_fingerprints.txt``.
         private let validFingerprints: Set<String>
 

--- a/ios/PrivateLine/NotificationManager.swift
+++ b/ios/PrivateLine/NotificationManager.swift
@@ -12,6 +12,10 @@ import LocalAuthentication
  *
  * 2025 update: retrieving the authorization token now requires a biometric
  * scan, ensuring push registration only occurs after the user authenticates.
+ *
+ * 2025 networking hardening: device token registration now performs TLS
+ * certificate pinning using ``APIService.PinningDelegate`` and reports
+ * failures via ``registrationFailureNotification`` so the UI may retry.
 */
 
 /// Helper used for configuring push notification permissions and
@@ -21,6 +25,10 @@ enum NotificationManager {
     /// Storage key used for persisting the last known APNs token. Using a
     /// constant avoids typos and centralises the value for future updates.
     private static let tokenKey = "apnsDeviceToken"
+
+    /// Notification emitted when the push token registration fails. The UI can
+    /// observe this to prompt the user to retry the operation.
+    static let registrationFailureNotification = Notification.Name("DeviceTokenRegistrationFailed")
 
     /// Request notification authorization and register with APNs.
     static func requestAuthorization() {
@@ -41,8 +49,14 @@ enum NotificationManager {
     /// - Parameter deviceToken: Binary token provided by APNs during
     ///   registration. The method gracefully returns if authentication details
     ///   or the backend URL cannot be determined.
-    static func registerDeviceToken(_ deviceToken: Data) {
-        // Convert binary token to a hex string representation
+    static func registerDeviceToken(
+        _ deviceToken: Data,
+        session: URLSession? = nil,
+        baseURL: URL? = nil,
+        authToken: String? = nil
+    ) {
+        // Convert binary token to a hex string representation so it can be
+        // transmitted as JSON. APNs tokens are opaque, hence the hex encoding.
         let tokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
 
         // Detect whether this token matches the last value we sent to the
@@ -52,15 +66,25 @@ enum NotificationManager {
         if defaults.string(forKey: tokenKey) == tokenString {
             return
         }
-        defaults.set(tokenString, forKey: tokenKey)
 
-        // Retrieve the auth token, requiring biometric authentication. If the
-        // user cancels or authentication fails the registration attempt is
-        // skipped and will be retried on the next token refresh.
+        // Retrieve the auth token. Tests may inject a pre-defined value to
+        // bypass Keychain access which requires iOS APIs.
         let context = LAContext()
-        guard let auth = try? KeychainService.loadToken(context: context) else { return }
-        guard let urlString = Bundle.main.object(forInfoDictionaryKey: "BackendBaseURL") as? String,
-              let url = URL(string: urlString)?.appendingPathComponent("push-token") else { return }
+        guard let auth = authToken ?? (try? KeychainService.loadToken(context: context)) else { return }
+
+        // Determine the backend endpoint. Tests may supply ``baseURL`` to avoid
+        // relying on Info.plist configuration.
+        let base: URL
+        if let provided = baseURL {
+            base = provided
+        } else if let urlString = Bundle.main.object(forInfoDictionaryKey: "BackendBaseURL") as? String,
+                  let url = URL(string: urlString) {
+            base = url
+        } else {
+            return
+        }
+        let url = base.appendingPathComponent("push-token")
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.addValue("Bearer \(auth)", forHTTPHeaderField: "Authorization")
@@ -68,9 +92,28 @@ enum NotificationManager {
         let body = ["token": tokenString, "platform": "ios"]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
-        // Fire and forget the registration request. No response handling is
-        // necessary because the backend does not return useful data. Errors are
-        // ignored; a new token will trigger another attempt later.
-        URLSession.shared.dataTask(with: request).resume()
+        // Use the supplied session or create one with certificate pinning so the
+        // token is only sent to trusted servers.
+        let session = session ?? URLSession(
+            configuration: .default,
+            delegate: APIService.PinningDelegate(),
+            delegateQueue: nil
+        )
+
+        session.dataTask(with: request) { _, response, error in
+            // Any network or server error should prevent caching the token so a
+            // subsequent attempt can retry the request. Post a notification so
+            // the UI may inform the user.
+            guard error == nil,
+                  let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode) else {
+                defaults.removeObject(forKey: tokenKey)
+                NotificationCenter.default.post(name: registrationFailureNotification, object: error)
+                return
+            }
+
+            // Persist the token only after the server acknowledges receipt.
+            defaults.set(tokenString, forKey: tokenKey)
+        }.resume()
     }
 }

--- a/ios/PrivateLineTests/NotificationManagerTests.swift
+++ b/ios/PrivateLineTests/NotificationManagerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import PrivateLine
+
+/// Tests covering the push-notification registration helper.
+///
+/// Focuses on error propagation so the UI can prompt users to retry when the
+/// backend rejects the certificate presented during TLS handshake.
+final class NotificationManagerTests: XCTestCase {
+    /// Simulates a connection to a server whose certificate is not pinned.
+    /// A delegate cancels the authentication challenge, mirroring how
+    /// ``APIService.PinningDelegate`` reacts to unknown fingerprints. The test
+    /// verifies that ``NotificationManager`` posts a failure notification and
+    /// avoids caching the token so a subsequent attempt can retry.
+    func testRegistrationFailsForUnpinnedCertificate() {
+        // Ensure a clean slate so persistence checks are accurate.
+        UserDefaults.standard.removeObject(forKey: "apnsDeviceToken")
+
+        // Expect a failure notification which indicates that the registration
+        // did not succeed and the UI should offer a retry option.
+        let exp = expectation(forNotification: NotificationManager.registrationFailureNotification,
+                              object: nil,
+                              handler: nil)
+
+        // Sample token content; the actual value is irrelevant for the test.
+        let token = Data([0x00, 0x01, 0x02, 0x03])
+
+        // Delegate that rejects all TLS challenges to mimic an unpinned cert.
+        class RejectingDelegate: NSObject, URLSessionDelegate {
+            func urlSession(_ session: URLSession,
+                            didReceive challenge: URLAuthenticationChallenge,
+                            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            }
+        }
+        let session = URLSession(configuration: .default,
+                                 delegate: RejectingDelegate(),
+                                 delegateQueue: nil)
+
+        // Attempt to register against an arbitrary HTTPS endpoint. The request
+        // will fail during the TLS handshake due to the rejecting delegate.
+        NotificationManager.registerDeviceToken(token,
+                                                session: session,
+                                                baseURL: URL(string: "https://example.com")!,
+                                                authToken: "dummy")
+
+        wait(for: [exp], timeout: 5.0)
+
+        // After failure the token should remain unset to allow a retry.
+        XCTAssertNil(UserDefaults.standard.string(forKey: "apnsDeviceToken"),
+                     "Token should not persist after failed registration")
+    }
+}


### PR DESCRIPTION
## Summary
- Replace push token registration with a pinned URLSession and surface failures via notification.
- Expose `APIService.PinningDelegate` for reuse across the app.
- Add unit test ensuring registration reports failure when TLS pinning rejects the certificate.

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*