### PR TITLE
feat: add loading indicators to chat and login flows

### DIFF
--- a/ios/PrivateLine/ChatView.swift
+++ b/ios/PrivateLine/ChatView.swift
@@ -11,6 +11,9 @@
  * - The contact picker now sources usernames from ``ChatViewModel.contacts``
  *   which are retrieved from the backend on view load, replacing the
  *   previously hard-coded list.
+ * - Displays a ``ProgressView`` overlay while ``ChatViewModel`` performs
+ *   network requests and disables interactive controls to prevent duplicate
+ *   actions.
  */
 import SwiftUI
 
@@ -26,9 +29,10 @@ struct ChatView: View {
     @State private var showError = false
 
     var body: some View {
-        VStack {
-            // Picker allowing the user to switch between direct and group chats.
-            Picker("Conversation", selection: Binding(
+        ZStack {
+            VStack {
+                // Picker allowing the user to switch between direct and group chats.
+                Picker("Conversation", selection: Binding(
                 get: { viewModel.selectedGroup == nil ? viewModel.recipient : "g\(viewModel.selectedGroup!)" },
                 set: { val in
                     if val.hasPrefix("g") {
@@ -42,76 +46,83 @@ struct ChatView: View {
                     // message history so the picker always reflects current
                     // server state.
                     Task { await load() }
-                })) {
-                // Dynamically retrieved direct message contacts
-                ForEach(viewModel.contacts, id: \.self) { u in
-                    Text(u).tag(u)
+                )) {
+                    // Dynamically retrieved direct message contacts
+                    ForEach(viewModel.contacts, id: \.self) { u in
+                        Text(u).tag(u)
+                    }
+                    // Dynamically loaded group conversations
+                    ForEach(viewModel.groups) { g in
+                        Text(g.name).tag("g\(g.id)")
+                    }
                 }
-                // Dynamically loaded group conversations
-                ForEach(viewModel.groups) { g in
-                    Text(g.name).tag("g\(g.id)")
+                .pickerStyle(MenuPickerStyle())
+                .disabled(viewModel.isLoading)
+                // Show decrypted chat messages with read receipts and attachments.
+                List(viewModel.messages) { msg in
+                    HStack {
+                        Text(msg.content)
+                        if let read = msg.read, msg.id != 0 {
+                            Spacer()
+                            Image(systemName: read ? "checkmark.circle.fill" : "checkmark.circle")
+                                .foregroundColor(.gray)
+                        }
+                        if let fid = msg.file_id {
+                            // Download link for an optional file attachment
+                            Link("attachment", destination: URL(string: "\(viewModel.api.baseURLString)/files/\(fid)")!)
+                        }
+                    }
+                        .accessibilityLabel("Message: \(msg.content)")
                 }
-            }
-            .pickerStyle(MenuPickerStyle())
-            // Show decrypted chat messages with read receipts and attachments.
-            List(viewModel.messages) { msg in
+                // Input field, optional attachment picker and send button.
                 HStack {
-                    Text(msg.content)
-                    if let read = msg.read, msg.id != 0 {
-                        Spacer()
-                        Image(systemName: read ? "checkmark.circle.fill" : "checkmark.circle")
-                            .foregroundColor(.gray)
+                    // Text field bound to the view model's input
+                    TextField("Message", text: $viewModel.input)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    // Optional attachment picker presented modally
+                    Button("Attach") {
+                        showPicker = true
                     }
-                    if let fid = msg.file_id {
-                        // Download link for an optional file attachment
-                        Link("attachment", destination: URL(string: "\(viewModel.api.baseURLString)/files/\(fid)")!)
+                    .fileImporter(isPresented: $showPicker, allowedContentTypes: [.data]) { result in
+                        if case let .success(url) = result, let data = try? Data(contentsOf: url) {
+                            viewModel.attachment = data
+                        }
                     }
+                    // Choose optional expiration time for the message
+                    Stepper(value: $viewModel.expiresInMinutes, in: 0...1440, step: 10) {
+                        Text(viewModel.expiresInMinutes == 0 ? "No expiry" : "Expires in \(Int(viewModel.expiresInMinutes)) min")
+                            .font(.caption)
+                    }
+                    // Tapping the send icon encrypts and uploads the message
+                    Button(action: { Task { await viewModel.send() } }) {
+                        Image(systemName: "paperplane.fill")
+                    }
+                    .accessibilityLabel("Send message")
                 }
-                    .accessibilityLabel("Message: \(msg.content)")
+                .disabled(viewModel.isLoading)
             }
-            // Input field, optional attachment picker and send button.
-            HStack {
-                // Text field bound to the view model's input
-                TextField("Message", text: $viewModel.input)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                // Optional attachment picker presented modally
-                Button("Attach") {
-                    showPicker = true
-                }
-                .fileImporter(isPresented: $showPicker, allowedContentTypes: [.data]) { result in
-                    if case let .success(url) = result, let data = try? Data(contentsOf: url) {
-                        viewModel.attachment = data
-                    }
-                }
-                // Choose optional expiration time for the message
-                Stepper(value: $viewModel.expiresInMinutes, in: 0...1440, step: 10) {
-                    Text(viewModel.expiresInMinutes == 0 ? "No expiry" : "Expires in \(Int(viewModel.expiresInMinutes)) min")
-                        .font(.caption)
-                }
-                // Tapping the send icon encrypts and uploads the message
-                Button(action: { Task { await viewModel.send() } }) {
-                    Image(systemName: "paperplane.fill")
-                }
-                .accessibilityLabel("Send message")
+            // Load contacts and initial messages, then connect the WebSocket.
+            .onAppear { Task { await load() } }
+            // Persist state and close the socket when the view disappears
+            .onDisappear { viewModel.disconnect() }
+            .padding()
+            // Animate list updates when new messages arrive
+            .animation(.default, value: viewModel.messages)
+            // Present human readable errors surfaced by the view model.
+            .alert("Error", isPresented: $showError, presenting: viewModel.lastError) { _ in
+                // Reset error once dismissed so future failures display again.
+                Button("OK", role: .cancel) { viewModel.lastError = nil }
+            } message: { err in
+                Text(err)
             }
-        }
-        // Load contacts and initial messages, then connect the WebSocket.
-        .onAppear { Task { await load() } }
-        // Persist state and close the socket when the view disappears
-        .onDisappear { viewModel.disconnect() }
-        .padding()
-        // Animate list updates when new messages arrive
-        .animation(.default, value: viewModel.messages)
-        // Present human readable errors surfaced by the view model.
-        .alert("Error", isPresented: $showError, presenting: viewModel.lastError) { _ in
-            // Reset error once dismissed so future failures display again.
-            Button("OK", role: .cancel) { viewModel.lastError = nil }
-        } message: { err in
-            Text(err)
-        }
-        // Whenever a new error arrives, toggle the alert visibility.
-        .onChange(of: viewModel.lastError) { newValue in
-            showError = newValue != nil
+            // Whenever a new error arrives, toggle the alert visibility.
+            .onChange(of: viewModel.lastError) { newValue in
+                showError = newValue != nil
+            }
+
+            if viewModel.isLoading {
+                ProgressView()
+            }
         }
     }
 

--- a/ios/PrivateLine/LoginView.swift
+++ b/ios/PrivateLine/LoginView.swift
@@ -1,3 +1,8 @@
+/*
+ * LoginView.swift - Authentication screen for login and registration.
+ * Displays forms bound to ``LoginViewModel`` and surfaces backend errors.
+ * Shows a ``ProgressView`` overlay while requests are in flight.
+ */
 import SwiftUI
 
 /// View presenting login and registration forms.
@@ -6,39 +11,45 @@ struct LoginView: View {
     @StateObject var viewModel: LoginViewModel
 
     var body: some View {
-        VStack(spacing: 12) {
-            // Toggle between registration and login forms.
-            if viewModel.isRegistering {
-                TextField("Username", text: $viewModel.username)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                TextField("Email", text: $viewModel.email)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                SecureField("Password", text: $viewModel.password)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                // Submit registration details to the backend
-                Button("Register") {
-                    Task { await viewModel.register() }
+        ZStack {
+            VStack(spacing: 12) {
+                // Toggle between registration and login forms.
+                if viewModel.isRegistering {
+                    TextField("Username", text: $viewModel.username)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    TextField("Email", text: $viewModel.email)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    SecureField("Password", text: $viewModel.password)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    // Submit registration details to the backend
+                    Button("Register") {
+                        Task { await viewModel.register() }
+                    }
+                    Button("Back to Login") { viewModel.isRegistering = false }
+                } else {
+                    TextField("Username", text: $viewModel.username)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    SecureField("Password", text: $viewModel.password)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    // Trigger an async login request
+                    Button(action: { Task { await viewModel.login() } }) {
+                        Label("Login", systemImage: "lock.open")
+                    }
+                    // Switch to the registration form
+                    Button("Create Account") { viewModel.isRegistering = true }
                 }
-                Button("Back to Login") { viewModel.isRegistering = false }
-            } else {
-                TextField("Username", text: $viewModel.username)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                SecureField("Password", text: $viewModel.password)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                // Trigger an async login request
-                Button(action: { Task { await viewModel.login() } }) {
-                    Label("Login", systemImage: "lock.open")
+                // Display backend error messages inline.
+                if let error = viewModel.errorMessage {
+                    // Show any login or registration failures
+                    Text(error).foregroundColor(.red)
+                        .accessibilityLabel("Error: \(error)")
                 }
-                // Switch to the registration form
-                Button("Create Account") { viewModel.isRegistering = true }
             }
-            // Display backend error messages inline.
-            if let error = viewModel.errorMessage {
-                // Show any login or registration failures
-                Text(error).foregroundColor(.red)
-                    .accessibilityLabel("Error: \(error)")
+            .padding()
+            .disabled(viewModel.isLoading)
+            if viewModel.isLoading {
+                ProgressView()
             }
         }
-        .padding()
     }
 }

--- a/ios/PrivateLine/LoginViewModel.swift
+++ b/ios/PrivateLine/LoginViewModel.swift
@@ -1,3 +1,8 @@
+/*
+ * LoginViewModel.swift - Observable state for authentication forms.
+ * Coordinates login and registration requests while exposing progress and
+ * error information to ``LoginView``.
+ */
 import Foundation
 import Combine
 
@@ -15,6 +20,10 @@ final class LoginViewModel: ObservableObject {
     @Published var isRegistering = false
     /// Optional error string displayed below the form.
     @Published var errorMessage: String?
+    /// Indicates whether an authentication request is in progress.
+    /// Views use this to present ``ProgressView`` and disable form controls
+    /// to avoid duplicate submissions.
+    @Published var isLoading = false
 
     /// Underlying API service used to talk to the backend.
     private let api: APIService
@@ -29,6 +38,9 @@ final class LoginViewModel: ObservableObject {
             errorMessage = "Please enter a username and password"
             return
         }
+        // Show loading indicator while authentication request is in flight.
+        isLoading = true
+        defer { isLoading = false } // Always reset on completion or error
         do {
             // Forward credentials to the API service
             try await api.login(username: username, password: password)
@@ -43,6 +55,9 @@ final class LoginViewModel: ObservableObject {
             errorMessage = "Enter a valid email and a strong password"
             return
         }
+        // Mark registration as loading to disable the form and show progress.
+        isLoading = true
+        defer { isLoading = false } // Ensure the flag resets even if an error occurs
         do {
             // Send the registration request to the backend
             try await api.register(username: username, email: email, password: password)

--- a/ios/PrivateLineTests/LoginViewModelTests.swift
+++ b/ios/PrivateLineTests/LoginViewModelTests.swift
@@ -1,0 +1,78 @@
+/*
+ * LoginViewModelTests.swift - Unit tests for LoginViewModel.
+ * Verifies loading state toggling and validation error handling for
+ * authentication actions.
+ */
+import XCTest
+@testable import PrivateLine
+
+/// Mock API service for authentication endpoints with controllable delays and
+/// failure switches. This allows deterministic tests without real networking.
+final class AuthMockAPI: APIService {
+    enum Failure: Error { case login, register }
+
+    /// Flags to trigger thrown errors for specific calls.
+    var shouldFailLogin = false
+    var shouldFailRegister = false
+    /// Artificial latency applied before returning from calls.
+    var delayNanoseconds: UInt64 = 0
+
+    override init(session: URLSession? = nil) {
+        try! super.init(session: session,
+                        baseURL: URL(string: "https://example.com/api")!)
+    }
+
+    override func login(username: String, password: String) async throws {
+        if delayNanoseconds > 0 { try await Task.sleep(nanoseconds: delayNanoseconds) }
+        if shouldFailLogin { throw Failure.login }
+    }
+
+    override func register(username: String, email: String, password: String) async throws {
+        if delayNanoseconds > 0 { try await Task.sleep(nanoseconds: delayNanoseconds) }
+        if shouldFailRegister { throw Failure.register }
+    }
+}
+
+/// Tests exercising ``LoginViewModel`` loading and validation behavior.
+final class LoginViewModelTests: XCTestCase {
+    /// Logging in should toggle ``isLoading`` so the UI can show a progress indicator.
+    func testLoginTogglesLoadingState() async {
+        let api = AuthMockAPI()
+        api.delayNanoseconds = 50_000_000
+        let vm = LoginViewModel(api: api)
+        vm.username = "alice"
+        vm.password = "password"
+        let task = Task { await vm.login() }
+        await Task.yield()
+        XCTAssertTrue(vm.isLoading)
+        await task.value
+        XCTAssertFalse(vm.isLoading)
+    }
+
+    /// Validation failures should not set ``isLoading`` and must produce an error.
+    func testLoginValidationFailure() async {
+        let api = AuthMockAPI()
+        let vm = LoginViewModel(api: api)
+        vm.username = ""
+        vm.password = "123"
+        await vm.login()
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertNotNil(vm.errorMessage)
+    }
+
+    /// Registration also toggles ``isLoading`` and resets it when complete.
+    func testRegisterTogglesLoadingState() async {
+        let api = AuthMockAPI()
+        api.delayNanoseconds = 50_000_000
+        let vm = LoginViewModel(api: api)
+        vm.username = "alice"
+        vm.email = "a@example.com"
+        vm.password = "strongpassword"
+        vm.isRegistering = true
+        let task = Task { await vm.register() }
+        await Task.yield()
+        XCTAssertTrue(vm.isLoading)
+        await task.value
+        XCTAssertFalse(vm.isLoading)
+    }
+}


### PR DESCRIPTION
## Summary
- track network activity with `isLoading` in chat and login view models
- disable controls and overlay progress indicators in ChatView and LoginView
- cover loading state toggles and validation errors in unit tests

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*