### PR TITLE
Add SwiftUI message row with expiry indicator

### DIFF
--- a/ios/PrivateLine/ChatView.swift
+++ b/ios/PrivateLine/ChatView.swift
@@ -60,19 +60,7 @@ struct ChatView: View {
                 .disabled(viewModel.isLoading)
                 // Show decrypted chat messages with read receipts and attachments.
                 List(viewModel.messages) { msg in
-                    HStack {
-                        Text(msg.content)
-                        if let read = msg.read, msg.id != 0 {
-                            Spacer()
-                            Image(systemName: read ? "checkmark.circle.fill" : "checkmark.circle")
-                                .foregroundColor(.gray)
-                        }
-                        if let fid = msg.file_id {
-                            // Download link for an optional file attachment
-                            Link("attachment", destination: URL(string: "\(viewModel.api.baseURLString)/files/\(fid)")!)
-                        }
-                    }
-                        .accessibilityLabel("Message: \(msg.content)")
+                    MessageRow(message: msg, baseURL: viewModel.api.baseURLString)
                 }
                 // Input field, optional attachment picker and send button.
                 HStack {

--- a/ios/PrivateLine/MessageRow.swift
+++ b/ios/PrivateLine/MessageRow.swift
@@ -1,0 +1,94 @@
+/*
+ * MessageRow.swift - Reusable SwiftUI view for rendering a single chat message.
+ *
+ * This component encapsulates the visual representation of a message including
+ * bubble styling, timestamp and expiry indicator. It is used by ``ChatView`` to
+ * display conversation history.
+ *
+ * Usage example:
+ * ```swift
+ * List(messages) { msg in
+ *     MessageRow(message: msg, baseURL: api.baseURLString)
+ * }
+ * ```
+ *
+ * Design decisions:
+ * - The message bubble aligns to the leading edge for incoming messages and to
+ *   the trailing edge for messages authored by the local user (identified by a
+ *   ``nil`` sender field).
+ * - ``expires_at`` triggers a small "Expires" badge to communicate ephemerality
+ *   to the user.
+ * - A formatted timestamp is derived from ``id`` which represents the message's
+ *   creation time in seconds since the epoch when generated locally. Server
+ *   provided identifiers may not encode time but are still rendered for
+ *   consistency.
+ */
+import SwiftUI
+
+/// Visual representation of a single chat message including metadata.
+struct MessageRow: View {
+    /// Message being presented within the row.
+    let message: Message
+    /// Base URL string used to build download links for attachments.
+    let baseURL: String
+
+    /// Convenience flag identifying whether the message was authored by the
+    /// current user. Messages sent from this device are stored with a ``nil``
+    /// sender which we interpret as local.
+    private var isCurrentUser: Bool { message.sender == nil }
+
+    /// Time the message was created, formatted for display. Because the backend
+    /// does not expose an explicit timestamp, we interpret ``id`` as a Unix
+    /// epoch when locally generated. If ``id`` does not represent a valid time
+    /// the date formatter gracefully falls back to the Unix epoch.
+    private var formattedTimestamp: String {
+        let date = Date(timeIntervalSince1970: TimeInterval(message.id))
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    var body: some View {
+        HStack {
+            if isCurrentUser { Spacer() }
+            VStack(alignment: isCurrentUser ? .trailing : .leading, spacing: 4) {
+                // Message bubble with text and optional attachment link.
+                VStack(alignment: isCurrentUser ? .trailing : .leading, spacing: 2) {
+                    Text(message.content)
+                    if let fid = message.file_id {
+                        Link("attachment", destination: URL(string: "\(baseURL)/files/\(fid)")!)
+                    }
+                }
+                .padding(8)
+                .background(isCurrentUser ? Color.blue : Color.gray.opacity(0.2))
+                .foregroundColor(isCurrentUser ? .white : .black)
+                .cornerRadius(12)
+
+                // Timestamp, read receipt and optional expiry badge.
+                HStack(spacing: 4) {
+                    Text(formattedTimestamp)
+                        .font(.caption2)
+                        .foregroundColor(.gray)
+                    if let read = message.read, isCurrentUser, message.id != 0 {
+                        Image(systemName: read ? "checkmark.circle.fill" : "checkmark.circle")
+                            .foregroundColor(.gray)
+                    }
+                    if message.expires_at != nil {
+                        Text("Expires")
+                            .font(.caption2)
+                            .padding(2)
+                            .background(Color.red.opacity(0.8))
+                            .foregroundColor(.white)
+                            .cornerRadius(4)
+                            .accessibilityLabel("Expires")
+                    }
+                }
+            }
+            if !isCurrentUser { Spacer() }
+        }
+        .padding(.vertical, 2)
+        .accessibilityLabel("Message: \(message.content)")
+    }
+}
+

--- a/ios/PrivateLineTests/MessageRowTests.swift
+++ b/ios/PrivateLineTests/MessageRowTests.swift
@@ -1,0 +1,52 @@
+// MessageRowTests.swift
+// Unit tests verifying ``MessageRow`` renders metadata for expiring and
+// permanent messages. The tests inspect the view's textual description to
+// confirm presence or absence of the "Expires" badge without relying on
+// platform-specific rendering.
+//
+// Rationale:
+// - Messages with ``expires_at`` should visually display an "Expires" badge.
+// - Messages without an expiration timestamp must omit the badge.
+//
+// These tests run only when SwiftUI is available. On platforms lacking the
+// framework (e.g. Linux CI builders) the ``canImport`` check skips compilation
+// while still exercising the rest of the package.
+#if canImport(SwiftUI)
+import XCTest
+import SwiftUI
+@testable import PrivateLine
+
+/// Test suite ensuring ``MessageRow`` correctly reflects expiry metadata.
+final class MessageRowTests: XCTestCase {
+    /// Rows for expiring messages should include the "Expires" badge text.
+    func testRowWithExpiryShowsBadge() {
+        let msg = Message(id: 1,
+                          content: "hi",
+                          file_id: nil,
+                          read: nil,
+                          expires_at: Date(),
+                          sender: "alice",
+                          signature: nil)
+        let row = MessageRow(message: msg, baseURL: "https://example.com")
+        let description = String(describing: row.body)
+        XCTAssertTrue(description.contains("Expires"),
+                      "Expiring message should display an Expires badge")
+    }
+
+    /// Rows for permanent messages should not contain the "Expires" badge.
+    func testRowWithoutExpiryOmitsBadge() {
+        let msg = Message(id: 2,
+                          content: "hello",
+                          file_id: nil,
+                          read: nil,
+                          expires_at: nil,
+                          sender: "alice",
+                          signature: nil)
+        let row = MessageRow(message: msg, baseURL: "https://example.com")
+        let description = String(describing: row.body)
+        XCTAssertFalse(description.contains("Expires"),
+                       "Non-expiring message should not display an Expires badge")
+    }
+}
+#endif
+


### PR DESCRIPTION
## Summary
- extract chat message layout into reusable `MessageRow` view with bubbles, timestamps and expiry badge
- use `MessageRow` in `ChatView` for cleaner list rows
- add unit tests covering expiry badge visibility

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*