### PR TITLE
feat: add conversation list and selection tests

### DIFF
--- a/ios/PrivateLine/ConversationListView.swift
+++ b/ios/PrivateLine/ConversationListView.swift
@@ -1,0 +1,64 @@
+/*
+ * ConversationListView.swift
+ * Presents all available direct and group conversations so the user can
+ * choose which thread to view in ``ChatView``.
+ *
+ * Usage:
+ * ``ConversationListView(viewModel: ChatViewModel(api: ...))``
+ *
+ * The list refreshes contacts and group metadata on appearance to reflect the
+ * server's current state. Selecting an item updates the bound
+ * ``ChatViewModel`` via ``selectConversation`` which triggers message loading
+ * for the chosen thread.
+ */
+import SwiftUI
+
+/// Lists known conversations grouped by type. Tapping a row updates the
+/// ``ChatViewModel`` and dismisses the view to reveal the refreshed chat.
+struct ConversationListView: View {
+    /// Shared view model providing conversation metadata and network calls.
+    @ObservedObject var viewModel: ChatViewModel
+    /// Environment dismiss action used to pop this view off the navigation stack.
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Section("Direct Messages") {
+                // Show each available contact returned from the backend.
+                ForEach(viewModel.contacts, id: \.self) { contact in
+                    Button(action: {
+                        Task {
+                            // Selecting a contact clears any group selection and
+                            // loads the appropriate conversation from the server.
+                            await viewModel.selectConversation(recipient: contact)
+                            dismiss()
+                        }
+                    }) {
+                        Text(contact)
+                    }
+                }
+            }
+            Section("Groups") {
+                // Present all group chats the user participates in.
+                ForEach(viewModel.groups) { group in
+                    Button(action: {
+                        Task {
+                            // Switching to a group chat triggers a message reload
+                            // for that group and returns to the main chat view.
+                            await viewModel.selectConversation(groupID: group.id)
+                            dismiss()
+                        }
+                    }) {
+                        Text(group.name)
+                    }
+                }
+            }
+        }
+        // Always load the latest conversation metadata when appearing.
+        .task {
+            await viewModel.fetchContacts()
+            await viewModel.fetchGroups()
+        }
+        .navigationTitle("Conversations")
+    }
+}

--- a/ios/PrivateLineTests/ConversationSelectionTests.swift
+++ b/ios/PrivateLineTests/ConversationSelectionTests.swift
@@ -1,0 +1,67 @@
+// ConversationSelectionTests.swift
+// Verifies that choosing a conversation updates ChatViewModel state and
+// retrieves the expected message history.
+//
+// These tests use a mock ``APIService`` to deterministically return predefined
+// messages and groups so that selection logic can be exercised without network
+// dependencies.
+
+import XCTest
+@testable import PrivateLine
+
+/// Mock API service supplying canned responses for messages and groups.
+/// Each method returns data configured by the test to simulate server output
+/// for the selected conversation.
+final class SelectionMockAPI: APIService {
+    var directMessages: [Message] = []
+    var groupMessages: [Message] = []
+    var groupsList: [Group] = []
+
+    override init(session: URLSession? = nil) {
+        try! super.init(session: session, baseURL: URL(string: "https://example.com/api")!)
+    }
+
+    override func fetchMessages() async throws -> [Message] { directMessages }
+    override func fetchGroupMessages(_ groupId: Int) async throws -> [Message] { groupMessages }
+    override func fetchGroups() async throws -> [Group] { groupsList }
+}
+
+/// Test suite confirming that selecting a conversation refreshes ``ChatViewModel``
+/// and loads the appropriate message history.
+final class ConversationSelectionTests: XCTestCase {
+
+    /// Choosing a direct contact should update ``recipient`` and fetch direct
+    /// messages while clearing any group selection.
+    func testSelectingDirectConversationLoadsMessages() async {
+        let api = SelectionMockAPI()
+        api.directMessages = [Message(id: 1, content: "hi", file_id: nil, read: true, expires_at: nil, sender: nil, signature: nil)]
+        let socket = try! WebSocketService(api: api,
+                                           url: URL(string: "wss://example.com")!,
+                                           session: URLSession(configuration: .ephemeral))
+        let vm = ChatViewModel(api: api, socket: socket)
+
+        await vm.selectConversation(recipient: "alice")
+
+        XCTAssertEqual(vm.recipient, "alice")
+        XCTAssertNil(vm.selectedGroup)
+        XCTAssertEqual(vm.messages.map { $0.content }, ["hi"])
+    }
+
+    /// Picking a group should set ``selectedGroup`` and load that group's
+    /// message history along with current group metadata.
+    func testSelectingGroupConversationLoadsMessages() async {
+        let api = SelectionMockAPI()
+        api.groupMessages = [Message(id: 2, content: "group", file_id: nil, read: true, expires_at: nil, sender: nil, signature: nil)]
+        api.groupsList = [Group(id: 2, name: "Study")]
+        let socket = try! WebSocketService(api: api,
+                                           url: URL(string: "wss://example.com")!,
+                                           session: URLSession(configuration: .ephemeral))
+        let vm = ChatViewModel(api: api, socket: socket)
+
+        await vm.selectConversation(groupID: 2)
+
+        XCTAssertEqual(vm.selectedGroup, 2)
+        XCTAssertEqual(vm.messages.map { $0.content }, ["group"])
+        XCTAssertEqual(vm.groups.first?.id, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- navigate to a new ConversationListView to choose direct or group chats
- refresh ChatViewModel when selecting conversations and fetch groups
- cover conversation switching with unit tests

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*